### PR TITLE
CUSDK-90-collection-dictionary-tostring

### DIFF
--- a/connect/util/Collection.hx
+++ b/connect/util/Collection.hx
@@ -300,13 +300,10 @@ class Collection<T> extends Base {
 
 
     /**
-        Returns a string representation of `this` Collection.
-
-        The result will include the individual elements' String representations
-        separated by comma. The enclosing [ ] may be missing on some platforms.
+        Returns a JSON string representation of `this` Collection.
     **/
     public function toString(): String {
-        return this._array.toString();
+        return haxe.Json.stringify(this._array);
     }
 
 

--- a/connect/util/Dictionary.hx
+++ b/connect/util/Dictionary.hx
@@ -243,11 +243,10 @@ class Dictionary extends Base {
 
 
     /**
-        Returns a String representation of `this` Dictionary.
-        The exact representation depends on the platform.
+        Returns a JSON string representation of `this` Dictionary.
     **/
     public function toString(): String {
-        return map.toString();
+        return haxe.Json.stringify(this.toObject());
     }
 
 


### PR DESCRIPTION
Make Collection.toString() and Dictionary.toString() return JSON representation instead of the platform dependent representation that they return now.