### PR TITLE
Cusdk 95 inquire params

### DIFF
--- a/connect/Flow.hx
+++ b/connect/Flow.hx
@@ -190,12 +190,12 @@ class Flow extends Base {
         final tcr = this.getTierConfigRequest();
         if (request != null) {
             StepStorage.removeStepData(request.id, getStepParam());
-            request.update();
+            request.update(null);
             request.approveByTemplate(id);
             this.abort('');
         } else if (tcr != null) {
             StepStorage.removeStepData(tcr.id, getStepParam());
-            tcr.update();
+            tcr.update(null);
             tcr.approveByTemplate(id);
             this.abort('');
         }
@@ -214,12 +214,12 @@ class Flow extends Base {
         final tcr = this.getTierConfigRequest();
         if (request != null) {
             StepStorage.removeStepData(request.id, getStepParam());
-            request.update();
+            request.update(null);
             request.approveByTile(text);
             this.abort('');
         } else if (tcr != null) {
             StepStorage.removeStepData(tcr.id, getStepParam());
-            tcr.update();
+            tcr.update(null);
             tcr.approveByTile(text);
             this.abort('');
         }
@@ -237,12 +237,12 @@ class Flow extends Base {
         final tcr = this.getTierConfigRequest();
         if (request != null) {
             StepStorage.removeStepData(request.id, getStepParam());
-            request.update();
+            request.update(null);
             request.fail(reason);
             this.abort('Failing request');
         } else if (tcr != null) {
             StepStorage.removeStepData(tcr.id, getStepParam());
-            tcr.update();
+            tcr.update(null);
             tcr.fail(reason);
             this.abort('Failing request');
         }
@@ -253,22 +253,25 @@ class Flow extends Base {
 
         When using the Flow, this method should be used instead of `AssetRequest.inquire()` or
         `TierConfigRequest.inquire()`, since this take care of cleaning the stored step
-        information, and automatically skips any further steps.
+        information, and automatically skips any further steps. Also, this method calls `update`
+        on the request before changing its status.
 
         @param templateId Id of the template to use in the portal, or `null` to not use any. This
         is only used for AssetRequests.
+        @param params A collection of parameters to update. If `null` is passed, then the
+        parameters that have changed in the request will be updated.
     **/
-    public function inquire(templateId:String):Void {
+    public function inquire(templateId:String, params: Collection<Param>):Void {
         final request = this.getAssetRequest();
         final tcr = this.getTierConfigRequest();
         if (request != null) {
             StepStorage.removeStepData(request.id, getStepParam());
-            request.update();
+            request.update(params);
             request.inquire(templateId);
             this.abort('Inquiring request');
         } else if (tcr != null) {
             StepStorage.removeStepData(tcr.id, getStepParam());
-            tcr.update();
+            tcr.update(params);
             tcr.inquire();
             this.abort('Inquiring request');
         }
@@ -286,12 +289,12 @@ class Flow extends Base {
         final tcr = this.getTierConfigRequest();
         if (request != null) {
             StepStorage.removeStepData(request.id, getStepParam());
-            request.update();
+            request.update(null);
             request.pend();
             this.abort('Pending request');
         } else if (tcr != null) {
             StepStorage.removeStepData(tcr.id, getStepParam());
-            tcr.update();
+            tcr.update(null);
             tcr.pend();
             this.abort('Pending request');
         }

--- a/connect/api/Query.hx
+++ b/connect/api/Query.hx
@@ -273,41 +273,31 @@ class Query extends Base {
             rql.push('select(${this.select_.join(',')})');
         }
 
-        final likeKeys = this.like_.keys();
-        if (likeKeys.hasNext()) {
-            for (key in likeKeys) {
-                rql.push('like($key,${this.like_.get(key)})');
-            }
+        final likeKeys = sortStringArray([for (k in this.like_.keys()) k]);
+        for (key in likeKeys) {
+            rql.push('like($key,${this.like_.get(key)})');
         }
 
-        final ilikeKeys = this.ilike_.keys();
-        if (ilikeKeys.hasNext()) {
-            for (key in ilikeKeys) {
-                rql.push('ilike($key,${this.ilike_.get(key)})');
-            }
+        final ilikeKeys = sortStringArray([for (k in this.ilike_.keys()) k]);
+        for (key in ilikeKeys) {
+            rql.push('ilike($key,${this.ilike_.get(key)})');
         }
 
-        final inKeys = this.in__.keys();
-        if (inKeys.hasNext()) {
-            for (key in inKeys) {
-                rql.push('in($key,(${this.in__.get(key).join(',')}))');
-            }
+        final inKeys = sortStringArray([for (k in this.in__.keys()) k]);
+        for (key in inKeys) {
+            rql.push('in($key,(${this.in__.get(key).join(',')}))');
         }
 
-        final outKeys = this.out_.keys();
-        if (outKeys.hasNext()) {
-            for (key in outKeys) {
-                rql.push('out($key,(${this.out_.get(key).join(',')}))');
-            }
+        final outKeys = sortStringArray([for (k in this.out_.keys()) k]);
+        for (key in outKeys) {
+            rql.push('out($key,(${this.out_.get(key).join(',')}))');
         }
 
-        final relOpsKeys = this.relOps.keys();
-        if (relOpsKeys.hasNext()) {
-            for (relOp in relOpsKeys) {
-                final arguments = this.relOps.get(relOp);
-                for (argument in arguments) {
-                    rql.push('$relOp(${argument.key},${argument.value})');
-                }
+        final relOpsKeys = sortStringArray([for (k in this.relOps.keys()) k]);
+        for (relOp in relOpsKeys) {
+            final arguments = this.relOps.get(relOp);
+            for (argument in arguments) {
+                rql.push('$relOp(${argument.key},${argument.value})');
             }
         }
 
@@ -526,6 +516,12 @@ class Query extends Base {
 
     private static function arrayToObject(arr:Array<Dynamic>): Array<Dynamic> {
         return Lambda.map(arr, elem -> valueToObject(elem));
+    }
+
+
+    private static function sortStringArray(arr: Array<String>): Array<String> {
+        haxe.ds.ArraySort.sort(arr, (a, b) -> Reflect.compare(a, b));
+        return arr;
     }
 }
 

--- a/connect/models/AssetRequest.hx
+++ b/connect/models/AssetRequest.hx
@@ -143,26 +143,37 @@ class AssetRequest extends IdModel {
     /**
         Updates the request in the server with the data changed in `this` model.
 
-        You should reassign your request with the object returned by this method, so the next time
-        you call `update` on the object, the SDK knows the fields that already got updated in a
-        previous call, like this:
+        If no parameters are specified for updating, you should reassign your request with the
+        object returned by this method, so the next time you call `update` on the object, the SDK
+        knows the fields that already got updated in a previous call, like this:
 
         ```
         request = request.update();
         ```
 
+        @param params A collection of parameters to update. If `null` is passed, then the
+        parameters that have changed in the request will be sent.
         @returns The AssetRequest returned from the server, which should contain
         the same data as `this` AssetRequest.
     **/
-    public function update(): AssetRequest {
-        final diff = this._toDiff();
-        final hasModifiedFields = Reflect.fields(diff).length > 1;
-        if (hasModifiedFields) {
-            final request = Env.getFulfillmentApi().updateRequest(
-                this.id,
-                haxe.Json.stringify(diff));
-            return Model.parse(AssetRequest, request);
+    public function update(params: Collection<Param>): AssetRequest {
+        if (params == null) {
+            final diff = this._toDiff();
+            final hasModifiedFields = Reflect.fields(diff).length > 1;
+            if (hasModifiedFields) {
+                final request = Env.getFulfillmentApi().updateRequest(
+                    this.id,
+                    haxe.Json.stringify(diff));
+                return Model.parse(AssetRequest, request);
+            } else {
+                return this;
+            }
         } else {
+            if (params.length() > 0) {
+                Env.getFulfillmentApi().updateRequest(
+                    this.id,
+                    '{"asset":{"params":${params.toString()}}}');
+            }
             return this;
         }
     }

--- a/connect/models/TierConfigRequest.hx
+++ b/connect/models/TierConfigRequest.hx
@@ -35,7 +35,7 @@ class TierConfigRequest extends IdModel {
 
 
     /** Tier level for product from customer perspective (1 or 2). **/
-    public var tierLevel: Int;
+    public var tierLevel: Null<Int>;
 
 
     /**
@@ -152,26 +152,37 @@ class TierConfigRequest extends IdModel {
     /**
         Updates the TierConfigRequest in the server with the data changed in `this` model.
 
-        You should reassign your request with the object returned by this method, so the next time
-        you call `update` on the object, the SDK knows the fields that already got updated in a
-        previous call, like this:
+        If no parameters are specified for updating, you should reassign your request with the
+        object returned by this method, so the next time you call `update` on the object, the SDK
+        knows the fields that already got updated in a previous call, like this:
 
         ```
         request = request.update();
         ```
 
+        @param params A collection of parameters to update. If `null` is passed, then the
+        parameters that have changed in the request will be sent.
         @returns The TierConfigRequest returned from the server, which should contain
         the same data as `this` TierConfigRequest.
     **/
-    public function update(): TierConfigRequest {
-        final diff = this._toDiff();
-        final hasModifiedFields = Reflect.fields(diff).length > 1;
-        if (hasModifiedFields) {
-            final request = Env.getTierApi().updateTierConfigRequest(
-                this.id,
-                haxe.Json.stringify(this._toDiff()));
-            return Model.parse(TierConfigRequest, request);
+    public function update(params: Collection<Param>): TierConfigRequest {
+        if (params == null) {
+            final diff = this._toDiff();
+            final hasModifiedFields = Reflect.fields(diff).length > 1;
+            if (hasModifiedFields) {
+                final request = Env.getTierApi().updateTierConfigRequest(
+                    this.id,
+                    haxe.Json.stringify(this._toDiff()));
+                return Model.parse(TierConfigRequest, request);
+            } else {
+                return this;
+            }
         } else {
+            if (params.length() > 0) {
+                Env.getTierApi().updateTierConfigRequest(
+                    this.id,
+                    '{"params":${params.toString()}}');
+            }
             return this;
         }
     }

--- a/connect/util/Collection.hx
+++ b/connect/util/Collection.hx
@@ -303,7 +303,11 @@ class Collection<T> extends Base {
         Returns a JSON string representation of `this` Collection.
     **/
     public function toString(): String {
-        return haxe.Json.stringify(this._array);
+        if (this.length() > 0 && Std.is(this.get(0), connect.models.Model)) {
+            return '[${this._array.map(el -> Std.string(el)).join(',')}]';
+        } else {
+            return haxe.Json.stringify(this._array);
+        }
     }
 
 

--- a/test/unit/AssetRequestTest.hx
+++ b/test/unit/AssetRequestTest.hx
@@ -131,8 +131,6 @@ class AssetRequestTest {
     public function testUpdateNoChanges() {
         // Check subject
         final request = AssetRequest.get('PR-5852-1608-0000');
-        //final modifiedFields = Reflect.fields(request._toDiff());
-        trace('*** ' + haxe.Json.stringify(request._toDiff()));
         final updatedRequest = request.update(null);
         Assert.isType(updatedRequest, AssetRequest);
         Assert.areEqual(request.toString(), updatedRequest.toString());

--- a/test/unit/AssetRequestTest.hx
+++ b/test/unit/AssetRequestTest.hx
@@ -131,6 +131,8 @@ class AssetRequestTest {
     public function testUpdateNoChanges() {
         // Check subject
         final request = AssetRequest.get('PR-5852-1608-0000');
+        final modifiedFields = Reflect.fields(request._toDiff());
+        trace('*** ' + haxe.Json.stringify(modifiedFields));
         final updatedRequest = request.update(null);
         Assert.isType(updatedRequest, AssetRequest);
         Assert.areEqual(request.toString(), updatedRequest.toString());

--- a/test/unit/AssetRequestTest.hx
+++ b/test/unit/AssetRequestTest.hx
@@ -113,7 +113,7 @@ class AssetRequestTest {
         // Check subject
         final request = AssetRequest.get('PR-5852-1608-0000');
         request.note = 'Hello, world!';
-        final updatedRequest = request.update();
+        final updatedRequest = request.update(null);
         Assert.isType(updatedRequest, AssetRequest);
         Assert.areEqual(AssetRequest.get('PR-5852-1608-0000').toString(), updatedRequest.toString());
         // ^ The mock returns that request
@@ -131,13 +131,34 @@ class AssetRequestTest {
     public function testUpdateNoChanges() {
         // Check subject
         final request = AssetRequest.get('PR-5852-1608-0000');
-        final updatedRequest = request.update();
+        final updatedRequest = request.update(null);
         Assert.isType(updatedRequest, AssetRequest);
         Assert.areEqual(request.toString(), updatedRequest.toString());
 
         // Check mocks
         final apiMock = cast(Env.getFulfillmentApi(), Mock);
         Assert.areEqual(0, apiMock.callCount('updateRequest'));
+    }
+
+
+    @Test
+    public function testUpdateWithParams() {
+        // Check subject
+        final param = new Param();
+        param.id = 'PM-9861-7949-8492-0001';
+        param.valueError = 'Please provide a value.';
+        final request = AssetRequest.get('PR-5852-1608-0000');
+        final updatedRequest = request.update(new Collection<Param>().push(param));
+        Assert.isType(updatedRequest, AssetRequest);
+        Assert.areEqual(request.toString(), updatedRequest.toString());
+
+        // Check mocks
+        final apiMock = cast(Env.getFulfillmentApi(), Mock);
+        Assert.areEqual(1, apiMock.callCount('updateRequest'));
+        final callArgs = apiMock.callArgs('updateRequest', 0);
+        Assert.areEqual(
+            [request.id, '{"asset":{"params":[{"id":"PM-9861-7949-8492-0001","value_error":"Please provide a value."}]}}'].toString(),
+            [callArgs[0], Helper.sortStringObject(AssetRequest, callArgs[1])].toString());
     }
 
 

--- a/test/unit/AssetRequestTest.hx
+++ b/test/unit/AssetRequestTest.hx
@@ -131,8 +131,8 @@ class AssetRequestTest {
     public function testUpdateNoChanges() {
         // Check subject
         final request = AssetRequest.get('PR-5852-1608-0000');
-        final modifiedFields = Reflect.fields(request._toDiff());
-        trace('*** ' + haxe.Json.stringify(modifiedFields));
+        //final modifiedFields = Reflect.fields(request._toDiff());
+        trace('*** ' + haxe.Json.stringify(request._toDiff()));
         final updatedRequest = request.update(null);
         Assert.isType(updatedRequest, AssetRequest);
         Assert.areEqual(request.toString(), updatedRequest.toString());

--- a/test/unit/FlowTest.hx
+++ b/test/unit/FlowTest.hx
@@ -83,7 +83,7 @@ class FlowTest {
     @Test
     public function testFlowRunInquire() {
         final flow = new Flow(null).step('Add dummy data', function(f:Flow):Void {
-            f.inquire("TMPL-0001");
+            f.inquire('TMPL-0001', null);
         }).step('Trace request data', function(f:Flow):Void {});
         this.flowRunner(flow);
     }
@@ -91,7 +91,7 @@ class FlowTest {
     @Test
     public function testFlowRunFail() {
         final flow = new Flow(null).step('Add dummy data', function(f:Flow):Void {
-            f.fail("Fail by default");
+            f.fail('Fail by default');
         }).step('Trace request data', function(f:Flow):Void {});
         this.flowRunner(flow);
     }

--- a/test/unit/Helper.hx
+++ b/test/unit/Helper.hx
@@ -3,7 +3,17 @@
     Copyright (c) 2019 Ingram Micro. All Rights Reserved.
 */
 
+import connect.models.Model;
+import haxe.Json;
+
+
 class Helper {
+    public static function sortStringObject<T>(cls: Class<T>, str: String): String {
+        final obj = cast(Model.parse(cls, str), Model).toObject();
+        return Json.stringify(sortObject(obj));
+    }
+
+
     public static function sortObject(obj: Dynamic): Dynamic {
         final sortedObj = {};
         final sortedFields = Reflect.fields(obj);
@@ -16,6 +26,7 @@ class Helper {
     private static function sortArrayObjects(arr: Array<Dynamic>): Array<Dynamic> {
         return Lambda.map(arr, elem -> sortValue(elem));
     }
+
 
     private static function sortValue(value: Dynamic): Dynamic {
         switch (Type.typeof(value)) {

--- a/test/unit/TierConfigRequestTest.hx
+++ b/test/unit/TierConfigRequestTest.hx
@@ -101,7 +101,7 @@ class TierConfigRequestTest {
         // Check subject
         final request = TierConfigRequest.get('TCR-000-000-000');
         request.getParamById('param_a').value = 'Hello, world!';
-        final updatedRequest = request.update();
+        final updatedRequest = request.update(null);
         Assert.isType(updatedRequest, TierConfigRequest);
         Assert.areEqual(TierConfigRequest.get('TCR-000-000-000').toString(),
             updatedRequest.toString());
@@ -120,13 +120,34 @@ class TierConfigRequestTest {
     public function testUpdateNoChanges() {
         // Check subject
         final request = TierConfigRequest.get('TCR-000-000-000');
-        final updatedRequest = request.update();
+        final updatedRequest = request.update(null);
         Assert.isType(updatedRequest, TierConfigRequest);
         Assert.areEqual(request.toString(), updatedRequest.toString());
 
         // Check mocks
         final apiMock = cast(Env.getTierApi(), Mock);
         Assert.areEqual(0, apiMock.callCount('updateTierConfigRequest'));
+    }
+
+
+    @Test
+    public function testUpdateWithParams() {
+        // Check subject
+        final param = new Param();
+        param.id = 'PM-9861-7949-8492-0001';
+        param.valueError = 'Please provide a value.';
+        final request = TierConfigRequest.get('TCR-000-000-000');
+        final updatedRequest = request.update(new Collection<Param>().push(param));
+        Assert.isType(updatedRequest, TierConfigRequest);
+        Assert.areEqual(request.toString(), updatedRequest.toString());
+
+        // Check mocks
+        final apiMock = cast(Env.getTierApi(), Mock);
+        Assert.areEqual(1, apiMock.callCount('updateTierConfigRequest'));
+        final callArgs = apiMock.callArgs('updateTierConfigRequest', 0);
+        Assert.areEqual(
+            [request.id, '{"params":[{"id":"PM-9861-7949-8492-0001","value_error":"Please provide a value."}]}'].toString(),
+            [callArgs[0], Helper.sortStringObject(TierConfigRequest, callArgs[1])].toString());
     }
 
 


### PR DESCRIPTION
Add a Collection<Param> parameter to Flow.inquire and request update methods:

- Flow.inquire
- AssetRequest.update
- TierConfigRequest.update

You can pass null as argument, in which case the parameters that have changed since the request was pulled will be uploaded (this is the current functionality).

Also, Query class now exports RQL requests putting keys in alphabetical order, to simplify unit testing.