### PR TITLE
Cusdk 100 plain logger formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ stuff/.project
 stuff/.settings
 coverage.json
 logs/step.dat
+lcov.info

--- a/connect/Env.hx
+++ b/connect/Env.hx
@@ -170,7 +170,7 @@ class Env extends Base {
 
     /**
         Returns the logger object. If it is not initialized, it will initialize it in the level
-        `Info` with a filename of "log.md".
+        `Info` with the path "logs".
 
         @returns The environment logger.
     **/

--- a/connect/Flow.hx
+++ b/connect/Flow.hx
@@ -474,9 +474,9 @@ class Flow extends Base {
 
         // Set log filename
         if (assetRequest != null || tierConfigRequest != null) {
-            Env.getLogger().setFilename('$provider/$hub/$marketplace/$product/$tierAccount.md');
+            Env.getLogger().setFilename('$provider/$hub/$marketplace/$product/$tierAccount');
         } else if (listing != null || usageFile != null) {
-            Env.getLogger().setFilename('usage/$provider/$marketplace.md');
+            Env.getLogger().setFilename('usage/$provider/$marketplace');
         }
 
         // Open log section

--- a/connect/api/impl/ApiClientImpl.hx
+++ b/connect/api/impl/ApiClientImpl.hx
@@ -259,7 +259,7 @@ class ApiClientImpl extends Base implements IApiClient {
             final fmt = handler.formatter;
             final requestList = new Collection<String>();
             if (headers != null) {
-                requestList.push('Headers:${getHeadersTable(headers, fmt)}');
+                requestList.push('Headers:\n${getHeadersTable(headers, fmt)}');
             }
             if (body != null) {
                 requestList.push(getFormattedData(body, 'Body', fmt));
@@ -321,7 +321,7 @@ class ApiClientImpl extends Base implements IApiClient {
             : String {
         final compact = Env.getLogger().getLevel() != Logger.LEVEL_DEBUG;
         if (Util.isJson(data)) {
-            final prefix = compact ? '$title (compact):' : '$title:';
+            final prefix = compact ? '$title (compact): ' : '$title:\n';
             final block = fmt.formatCodeBlock(
                 Env.getLogger().getLevel(),
                 Util.beautify(
@@ -329,7 +329,7 @@ class ApiClientImpl extends Base implements IApiClient {
                     Env.getLogger().isCompact(),
                     Env.getLogger().getLevel() != Logger.LEVEL_DEBUG),
                 'json');
-            return '$prefix $block';
+            return '$prefix$block';
         } else {
             final fixedBody = compact
                 ? StringTools.lpad(data.substr(data.length - 4), '*', data.length)

--- a/connect/api/impl/ApiClientImpl.hx
+++ b/connect/api/impl/ApiClientImpl.hx
@@ -272,7 +272,7 @@ class ApiClientImpl extends Base implements IApiClient {
             }
             Env.getLogger()._writeToHandler(
                 level,
-                fmt.formatBlock(level,'$firstMessage${fmt.formatList(level,requestList)}'),
+                fmt.formatBlock(level, '$firstMessage\n${fmt.formatList(level, requestList)}'),
                 handler);
         }
     }

--- a/connect/logger/ILoggerFormatter.hx
+++ b/connect/logger/ILoggerFormatter.hx
@@ -18,4 +18,5 @@ interface ILoggerFormatter {
     public function formatList(level:Int, list:Collection<String>):String;
     public function formatTable(level:Int, table:Collection<Collection<String>>):String;
     public function formatLine(level:Int, text:String):String;
+    public function getFileExtension():String;
 }

--- a/connect/logger/ILoggerFormatter.hx
+++ b/connect/logger/ILoggerFormatter.hx
@@ -12,7 +12,7 @@ import connect.util.Collection;
  * this interface (`MarkdownLoggerFormatter` by default) to write log messages.
  */
 interface ILoggerFormatter {
-    public function formatSection(level:Int, text:String):String;
+    public function formatSection(level:Int, sectionLevel:Int, text:String):String;
     public function formatBlock(level:Int, text:String):String;
     public function formatCodeBlock(level:Int, text:String, language:String):String;
     public function formatList(level:Int, list:Collection<String>):String;

--- a/connect/logger/Logger.hx
+++ b/connect/logger/Logger.hx
@@ -246,7 +246,7 @@ class Logger extends Base {
         for (i in 0...this.sections.length) {
             if (!this.sections[i].written) {
                 for (output in this.handlers) {
-                    final section = output.formatter.formatSection(level, this.sections[i].name);
+                    final section = output.formatter.formatSection(level, i+1, this.sections[i].name);
                     output.writer.writeLine(section);
                 }
                 this.sections[i].written = true;

--- a/connect/logger/Logger.hx
+++ b/connect/logger/Logger.hx
@@ -229,7 +229,7 @@ class Logger extends Base {
     @:dox(hide)
     public function _writeToHandler(level:Int, message:String, handler:LoggerHandler):Void {
         if (this.level >= level) {
-            this.writeSections();
+            this.writeSections(level);
             handler.writer.writeLine(handler.formatter.formatLine(level, message));
         }
     }
@@ -242,11 +242,11 @@ class Logger extends Base {
     private final regexMaskingList:Collection<EReg>;
     private final compact:Bool;
     
-    private function writeSections():Void {
+    private function writeSections(level:Int):Void {
         for (i in 0...this.sections.length) {
             if (!this.sections[i].written) {
                 for (output in this.handlers) {
-                    final section = output.formatter.formatSection(i + 1, this.sections[i].name);
+                    final section = output.formatter.formatSection(level, this.sections[i].name);
                     output.writer.writeLine(section);
                 }
                 this.sections[i].written = true;

--- a/connect/logger/Logger.hx
+++ b/connect/logger/Logger.hx
@@ -57,12 +57,13 @@ class Logger extends Base {
 
     /**
         Sets the filename of the log. All future log messages will get printed to this file.
-        Use `null` to only write to standard output.
+        Use `null` to only write to standard output. Filename extension must be omitted, since
+        it is provided by the formatters used in each handler.
     **/
     public function setFilename(filename:String):Void {
         final fullname = (this.path != null && filename != null) ? this.path + filename : null;
         final setFilenameResult = Lambda.fold(this.handlers, function(o, last) {
-            return last && o.writer.setFilename(fullname);
+            return last && o.writer.setFilename('$fullname.${o.formatter.getFileExtension()}');
         }, true);
         if (setFilenameResult && fullname != null) {
             for (section in this.sections) {

--- a/connect/logger/MarkdownLoggerFormatter.hx
+++ b/connect/logger/MarkdownLoggerFormatter.hx
@@ -5,6 +5,7 @@
 package connect.logger;
 
 import connect.util.Collection;
+import connect.util.Util;
 
 
 @:dox(hide)
@@ -18,15 +19,9 @@ class MarkdownLoggerFormatter extends Base implements ILoggerFormatter {
     }
 
     public function formatBlock(level: Int, text: String): String {
-        final lines = getLines(text);
+        final lines = Util.getLines(text);
         final prefixedLines = [for (line in lines) '> $line'];
         return '\n' + prefixedLines.join('\n') + '\n';
-    }
-
-    private static function getLines(text: String): Array<String> {
-        final windowsReplaced = StringTools.replace(text, '\r\n', '\n');
-        final macosReplaced = StringTools.replace(windowsReplaced, '\r', '\n');
-        return macosReplaced.split('\n');
     }
 
     public function formatCodeBlock(level: Int, text: String, language: String): String {
@@ -35,10 +30,10 @@ class MarkdownLoggerFormatter extends Base implements ILoggerFormatter {
         return header + text + footer;
     }
 
-    public function formatList(level: Int, lines: Collection<String>): String {
-        if (lines.length() > 0) {
-            final lines = [for (line in lines) '* $line'];
-            return '\n${lines.join('\n')}\n';
+    public function formatList(level: Int, list: Collection<String>): String {
+        if (list.length() > 0) {
+            final formatted = [for (line in list) '* $line'];
+            return '\n${formatted.join('\n')}\n';
         } else {
             return '\n\n';
         }

--- a/connect/logger/MarkdownLoggerFormatter.hx
+++ b/connect/logger/MarkdownLoggerFormatter.hx
@@ -54,5 +54,9 @@ class MarkdownLoggerFormatter extends Base implements ILoggerFormatter {
         return text;
     }
 
+    public function getFileExtension(): String {
+        return 'md';
+    }
+
     public function new() {}
 }

--- a/connect/logger/MarkdownLoggerFormatter.hx
+++ b/connect/logger/MarkdownLoggerFormatter.hx
@@ -10,8 +10,8 @@ import connect.util.Util;
 
 @:dox(hide)
 class MarkdownLoggerFormatter extends Base implements ILoggerFormatter {
-    public function formatSection(level: Int, text: String): String {
-        final hashes = StringTools.rpad('', '#', level);
+    public function formatSection(level: Int, sectionLevel: Int, text: String): String {
+        final hashes = StringTools.rpad('', '#', sectionLevel);
         final prefix = (hashes != '')
             ? (hashes + ' ')
             : '';

--- a/connect/logger/PlainLoggerFormatter.hx
+++ b/connect/logger/PlainLoggerFormatter.hx
@@ -1,0 +1,93 @@
+/*
+    This file is part of the Ingram Micro CloudBlue Connect SDK.
+    Copyright (c) 2019 Ingram Micro. All Rights Reserved.
+*/
+package connect.logger;
+
+import connect.util.Collection;
+import connect.util.DateTime;
+import connect.util.Util;
+
+
+@:dox(hide)
+class PlainLoggerFormatter extends Base implements ILoggerFormatter {
+    private static final NO_REQUEST = 'NO_REQUEST';
+    private static final REQUEST_PREFIX = 'Processing request "';
+
+    private var currentRequest = NO_REQUEST;
+
+    public function formatSection(level: Int, text: String): String {
+        final hashes = StringTools.rpad('', '#', level);
+        final sectionPrefix = (hashes != '')
+            ? (hashes + ' ')
+            : '';
+        this.parseCurrentRequest(level, text);
+        return '${formatPrefix(level)}$sectionPrefix$text\n';
+    }
+
+    private function parseCurrentRequest(level: Int, text: String): Void {
+        if (StringTools.startsWith(text, REQUEST_PREFIX)) {
+            final request = text.split('"')[1];
+            this.currentRequest = (request != '') ? request : NO_REQUEST;
+        }
+    }
+
+    private function formatPrefix(level: Int): String {
+        return '${formatDate()}  ${formatLevel(level)} ${this.currentRequest} - ';
+    }
+
+    private static function formatDate(): String {
+        final date = DateTime.now().toString();
+        return StringTools.replace(date.split('+')[0], 'T', ' ');
+    }
+
+    private static function formatLevel(level: Int): String {
+        final levelNames = [
+            'ERROR  ',
+            'WARNING',
+            'INFO   ',
+            'DEBUG  '
+        ];
+        return levelNames[level];
+    }
+
+    public function formatBlock(level: Int, text: String): String {
+        final prefix = formatPrefix(level);
+        final lines = Util.getLines(text);
+        final prefixedLines = [for (line in lines) '$prefix$line'];
+        return prefixedLines.join('\n') + '\n';
+    }
+
+    public function formatCodeBlock(level: Int, text: String, language: String): String {
+        final prefix = formatPrefix(level);
+        final lines = Util.getLines(text);
+        final formatted = [for (line in lines) '$prefix$line'];
+        return '${formatted.join('\n')}\n';
+    }
+
+    public function formatList(level: Int, list: Collection<String>): String {
+        if (list.length() > 0) {
+            final prefix = formatPrefix(level);
+            final formatted = [for (line in list) '$prefix* $line'];
+            return '${formatted.join('\n')}\n';
+        } else {
+            return '\n';
+        }
+    }
+
+    public function formatTable(level: Int, table: Collection<Collection<String>>): String {
+        if (table.length() > 0) {
+            final prefix = formatPrefix(level);
+            final rows = [for (row in table) '$prefix| ${row.join(' | ')} |'];
+            final header = rows[0];
+            final rest = rows.slice(1);
+            return '$header\n${rest.join('\n')}\n';
+        } else {
+            return '\n';
+        }
+    }
+
+    public function formatLine(level: Int, text: String): String {
+        return '${formatPrefix(level)}$text\n';
+    }
+}

--- a/connect/logger/PlainLoggerFormatter.hx
+++ b/connect/logger/PlainLoggerFormatter.hx
@@ -90,4 +90,8 @@ class PlainLoggerFormatter extends Base implements ILoggerFormatter {
     public function formatLine(level: Int, text: String): String {
         return '${formatPrefix(level)}$text\n';
     }
+
+    public function getFileExtension(): String {
+        return 'log';
+    }
 }

--- a/connect/logger/PlainLoggerFormatter.hx
+++ b/connect/logger/PlainLoggerFormatter.hx
@@ -33,7 +33,7 @@ class PlainLoggerFormatter extends Base implements ILoggerFormatter {
     }
 
     private function formatPrefix(level: Int): String {
-        return '${formatDate()}  ${formatLevel(level)} ${this.currentRequest} - ';
+        return '${formatDate()}  ${formatLevel(level)}   ${this.currentRequest} - ';
     }
 
     private static function formatDate(): String {
@@ -43,10 +43,10 @@ class PlainLoggerFormatter extends Base implements ILoggerFormatter {
 
     private static function formatLevel(level: Int): String {
         final levelNames = [
-            'ERROR  ',
+            'ERROR',
             'WARNING',
-            'INFO   ',
-            'DEBUG  '
+            'INFO',
+            'DEBUG'
         ];
         return (level >= 0 && level < levelNames.length)
             ? levelNames[level]

--- a/connect/util/Util.hx
+++ b/connect/util/Util.hx
@@ -156,6 +156,19 @@ class Util {
 
 
     /**
+     * Splits the given text into its lines, detecting Windows (CR+LF), Mac OS Classic (CR) and
+     * Unix (LF) line endings.
+     * @param text 
+     * @return Array<String> 
+     */
+    public static function getLines(text: String): Array<String> {
+        final windowsReplaced = StringTools.replace(text, '\r\n', '\n');
+        final macosReplaced = StringTools.replace(windowsReplaced, '\r', '\n');
+        return macosReplaced.split('\n');
+    }
+
+
+    /**
      * Creates a new dynamic object that contains the sames fields as `object`.
      * When a field contains a subobject that has no `id` field, but the respective
      * subobject in `original` contains an id field, the value is copied.

--- a/test/unit/CustomLoggerFormatterTest.hx
+++ b/test/unit/CustomLoggerFormatterTest.hx
@@ -14,7 +14,7 @@ import massive.munit.Assert;
 import connect.Base;
 
 class CustomLoggerFormatter extends Base implements ILoggerFormatter {
-    public function formatSection(level:Int, text:String):String {
+    public function formatSection(level:Int, sectionLevel:Int, text:String):String {
         return text;
     }
 

--- a/test/unit/CustomLoggerFormatterTest.hx
+++ b/test/unit/CustomLoggerFormatterTest.hx
@@ -51,6 +51,10 @@ class CustomLoggerFormatter extends Base implements ILoggerFormatter {
         }
         return textLevel + " - " + this.marketPlace + " - " + this.hub + " - " + this.customer + " - " + text;
     }
+
+    public function getFileExtension():String {
+        return 'txt';
+    }
 }
 
 class CustomLoggerFormatterTest {

--- a/test/unit/MarkdownLoggerFormatterTest.hx
+++ b/test/unit/MarkdownLoggerFormatterTest.hx
@@ -3,6 +3,7 @@
     Copyright (c) 2019 Ingram Micro. All Rights Reserved.
 */
 import connect.logger.ILoggerFormatter;
+import connect.logger.Logger;
 import connect.logger.MarkdownLoggerFormatter;
 import connect.util.Collection;
 import massive.munit.Assert;
@@ -16,11 +17,11 @@ class MarkdownLoggerFormatterTest {
 
     @Test
     public function testFormatSection() {
-        Assert.areEqual('\n## Hello\n', fmt.formatSection(2, 'Hello'));
-        Assert.areEqual('\n# Hello\n', fmt.formatSection(1, 'Hello'));
-        Assert.areEqual('\nHello\n', fmt.formatSection(0, 'Hello'));
-        Assert.areEqual('\nHello\n', fmt.formatSection(-1, 'Hello'));
-        Assert.areEqual('\n# \n', fmt.formatSection(1, ''));
+        Assert.areEqual('\n## Hello\n', fmt.formatSection(Logger.LEVEL_INFO, 2, 'Hello'));
+        Assert.areEqual('\n# Hello\n', fmt.formatSection(Logger.LEVEL_INFO, 1, 'Hello'));
+        Assert.areEqual('\nHello\n', fmt.formatSection(Logger.LEVEL_INFO, 0, 'Hello'));
+        Assert.areEqual('\nHello\n', fmt.formatSection(Logger.LEVEL_INFO, -1, 'Hello'));
+        Assert.areEqual('\n# \n', fmt.formatSection(Logger.LEVEL_INFO, 1, ''));
     }
 
 

--- a/test/unit/TestSuite.hx
+++ b/test/unit/TestSuite.hx
@@ -33,34 +33,35 @@ import DateTimeTest;
  */
 class TestSuite extends massive.munit.TestSuite
 {
-    public function new()
-    {
-        super();
-        add(LoggerTest);
-        add(MarketplaceTest);
-        add(TierAccountTest);
-        add(AssetTest);
-        add(MarkdownLoggerFormatterTest);
-        add(CategoryTest);
-        add(ItemTest);
-        add(ConfigurationTest);
-        add(CustomLoggerFormatterTest);
-        add(AccountTest);
-        add(TierConfigRequestTest);
-        add(DiffTest);
-        add(FlowAttemptsTest);
-        add(AgreementTest);
-        add(AssetRequestTest);
-        add(UsageFileTest);
-        add(TierConfigTest);
-        add(ConversationTest);
-        add(FlowTest);
-        add(ListingRequestTest);
-        add(ConfigTest);
-        add(ListingTest);
-        add(ModelTest);
-        add(QueryTest);
-        add(ProductTest);
-        add(DateTimeTest);
-    }
+	public function new()
+	{
+		super();
+
+		add(LoggerTest);
+		add(MarketplaceTest);
+		add(TierAccountTest);
+		add(AssetTest);
+		add(MarkdownLoggerFormatterTest);
+		add(CategoryTest);
+		add(ItemTest);
+		add(ConfigurationTest);
+		add(CustomLoggerFormatterTest);
+		add(AccountTest);
+		add(TierConfigRequestTest);
+		add(DiffTest);
+		add(FlowAttemptsTest);
+		add(AgreementTest);
+		add(AssetRequestTest);
+		add(UsageFileTest);
+		add(TierConfigTest);
+		add(ConversationTest);
+		add(FlowTest);
+		add(ListingRequestTest);
+		add(ConfigTest);
+		add(ListingTest);
+		add(ModelTest);
+		add(QueryTest);
+		add(ProductTest);
+		add(DateTimeTest);
+	}
 }

--- a/test/unit/UsageFileTest.hx
+++ b/test/unit/UsageFileTest.hx
@@ -326,6 +326,7 @@ class UsageFileTest {
             null,
             null,
             null,
+            null,
             null].toString(),
             apiMock.callArgs('syncRequest', 0).toString());
         final usageMock = cast(Env.getUsageApi(), Mock);


### PR DESCRIPTION
Added a PlainLoggerFormatter which conforms to the specification here: https://confluence.int.zone/pages/viewpage.action?pageId=944671602#id-08-ConnectSalesModels(DirectvsDistribution)-LogsStructure.

This is now the default formatter for connectors. In order to enable MarkdownLoggerFormatter, it is possible to call `markdown(true)` on the LoggerConfig object.