### PR TITLE
Cusdk 109 update tier params

### DIFF
--- a/connect/Flow.hx
+++ b/connect/Flow.hx
@@ -477,18 +477,26 @@ class Flow extends Base {
 
         // Get marketplace
         final marketplace =
-            (assetRequest != null && assetRequest.marketplace != null) ? assetRequest.marketplace.id :
-            (listing != null && listing.contract.marketplace != null) ? listing.contract.marketplace.id :
-            (tierConfigRequest != null && tierConfigRequest.marketplace != null) ? tierConfigRequest.marketplace.id :
-            (usageFile != null && usageFile.marketplace != null) ? usageFile.marketplace.id :
+            (assetRequest != null && assetRequest.marketplace != null) ?
+                assetRequest.marketplace.id :
+            (listing != null && listing.contract.marketplace != null) ?
+                listing.contract.marketplace.id :
+            (tierConfigRequest != null && tierConfigRequest.configuration.marketplace != null) ?
+                tierConfigRequest.configuration.marketplace.id :
+            (usageFile != null && usageFile.marketplace != null) ?
+                usageFile.marketplace.id :
             'marketplace';
 
         // Get product
         final product =
-            (assetRequest != null && assetRequest.asset.product != null) ? assetRequest.asset.product.id :
-            (listing != null && listing.product != null) ? listing.product.id :
-            (tierConfigRequest != null && tierConfigRequest.product != null) ? tierConfigRequest.product.id :
-            (usageFile != null && usageFile.product != null) ? usageFile.product.id :
+            (assetRequest != null && assetRequest.asset.product != null) ?
+                assetRequest.asset.product.id :
+            (listing != null && listing.product != null) ?
+                listing.product.id :
+            (tierConfigRequest != null && tierConfigRequest.configuration.product != null) ?
+                tierConfigRequest.configuration.product.id :
+            (usageFile != null && usageFile.product != null) ?
+                usageFile.product.id :
             'product';
         
         

--- a/connect/models/TierConfigRequest.hx
+++ b/connect/models/TierConfigRequest.hx
@@ -172,7 +172,7 @@ class TierConfigRequest extends IdModel {
             if (hasModifiedFields) {
                 final request = Env.getTierApi().updateTierConfigRequest(
                     this.id,
-                    haxe.Json.stringify(this._toDiff()));
+                    prepareUpdateBody(diff));
                 return Model.parse(TierConfigRequest, request);
             } else {
                 return this;
@@ -185,6 +185,28 @@ class TierConfigRequest extends IdModel {
             }
             return this;
         }
+    }
+
+
+    private static function prepareUpdateBody(diff: Dynamic): String {
+        final hasConfiguration = Reflect.hasField(diff, 'configuration');
+        final hasTcrParams = Reflect.hasField(diff, 'params');
+        final hasTcParams = hasConfiguration && Reflect.hasField(diff.configuration, 'params');
+        final hasConfigParams = hasConfiguration && Reflect.hasField(diff.configuration, 'configuration')
+            && Reflect.hasField(diff.configuration.configuration, 'params');
+        if ((hasTcParams || hasConfigParams) && !hasTcrParams) {
+            diff.params = [];
+        }
+        if (hasTcParams) {
+            diff.params = diff.params.concat(diff.configuration.params);
+        }
+        if (hasConfigParams) {
+            diff.params = diff.params.concat(diff.configuration.configuration.params);
+        }
+        if (hasConfiguration) {
+            Reflect.deleteField(diff, 'configuration');
+        }
+        return haxe.Json.stringify(diff);
     }
 
 

--- a/test/mocks/data/tierconfigrequest_list.json
+++ b/test/mocks/data/tierconfigrequest_list.json
@@ -6,6 +6,12 @@
         "configuration": {
             "id": "TC-000-000-000",
             "connection": {},
+            "params": [
+              {
+                "id": "tc_param",
+                "value": "tc_param_value"
+              }
+            ],
             "tiers": {}
         },
         "events": {

--- a/test/unit/TestSuite.hx
+++ b/test/unit/TestSuite.hx
@@ -23,6 +23,7 @@ import FlowTest;
 import ListingRequestTest;
 import ConfigTest;
 import ListingTest;
+import ModelTest;
 import QueryTest;
 import ProductTest;
 import DateTimeTest;
@@ -60,6 +61,7 @@ class TestSuite extends massive.munit.TestSuite
 		add(ListingRequestTest);
 		add(ConfigTest);
 		add(ListingTest);
+		add(ModelTest);
 		add(QueryTest);
 		add(ProductTest);
 		add(DateTimeTest);

--- a/test/unit/TierConfigRequestTest.hx
+++ b/test/unit/TierConfigRequestTest.hx
@@ -131,6 +131,24 @@ class TierConfigRequestTest {
 
 
     @Test
+    public function testUpdateWithTcParams() {
+        // Check subject
+        final request = TierConfigRequest.get('TCR-000-000-000');
+        request.configuration.getParamById('tc_param').value = 'New value';
+        request.update(null);
+        request.params = request.configuration.params;
+        Reflect.deleteField(request, 'configuration');
+
+        // Check mocks
+        final apiMock = cast(Env.getTierApi(), Mock);
+        Assert.areEqual(1, apiMock.callCount('updateTierConfigRequest'));
+        Assert.areEqual(
+            [request.id, request._toDiffString()].toString(),
+            apiMock.callArgs('updateTierConfigRequest', 0).toString());
+    }
+
+
+    @Test
     public function testUpdateWithParams() {
         // Check subject
         final param = new Param();


### PR DESCRIPTION
When updating a TierConfigRequest, only params are being updated, but not configuration.params nor configuration.configuration.params. Now all the modified parameters are moved to the params array of the TCR before being updated.

Also, the path of logs when processing TCRs have been fixed.