### PR TITLE
CUSDK-124: TCR approved by template are not correct

### DIFF
--- a/connect/models/TierConfigRequest.hx
+++ b/connect/models/TierConfigRequest.hx
@@ -204,7 +204,7 @@ class TierConfigRequest extends IdModel {
     **/
     public function approveByTemplate(id: String): Bool {
         try {
-            Env.getTierApi().approveTierConfigRequest(this.id, haxe.Json.stringify({template_id: id}));
+            Env.getTierApi().approveTierConfigRequest(this.id, haxe.Json.stringify({template: {id: id}}));
             return true;
         } catch (ex: Dynamic) {
             return false;

--- a/examples/example.py
+++ b/examples/example.py
@@ -23,6 +23,7 @@ def trace_request_data(p):
         + ' : ' + p.getData('productId') \
         + ' : ' + p.getData('status'))
 
+
 def approve_request(p):
     pass
     # p.getAssetRequest().approveByTemplate('TL-000-000-000')


### PR DESCRIPTION
TCR approved by template were using same parameter that asset request `{'template_id': id}`, but body format for TCR is different `{'template': {'id': id}}`.