### PR TITLE
CUSDK-125: Removed propagation of request id and duplication of log filename extension across processors

### DIFF
--- a/connect/logger/Logger.hx
+++ b/connect/logger/Logger.hx
@@ -104,13 +104,17 @@ class Logger extends Base {
 
     /** @returns The last filename that was set. **/
     public function getFilename():String {
-        final firstWriter = (this.handlers.length() > 0) ? this.handlers.get(0).writer : null;
-        if (firstWriter != null) {
-            final filename = firstWriter.getFilename();
-            final fixedFilename = (filename != null && filename.indexOf(this.path) == 0)
+        final firstHandler = (this.handlers.length() > 0) ? this.handlers.get(0) : null;
+        if (firstHandler != null) {
+            final filename = firstHandler.writer.getFilename();
+            final ext = firstHandler.formatter.getFileExtension();
+            final noPathFilename = (filename != null && filename.indexOf(this.path) == 0)
                 ? filename.substr(this.path.length)
                 : filename;
-            return fixedFilename;
+            final noExtFilename = (noPathFilename != null && ext != null && ext.length > 0)
+                ? noPathFilename.substr(0, noPathFilename.length - ext.length - 1)
+                : noPathFilename;
+            return noExtFilename;
         } else {
             return null;
         }

--- a/connect/logger/PlainLoggerFormatter.hx
+++ b/connect/logger/PlainLoggerFormatter.hx
@@ -15,6 +15,7 @@ class PlainLoggerFormatter extends Base implements ILoggerFormatter {
     private static final REQUEST_PREFIX = 'Processing request "';
 
     private var currentRequest = NO_REQUEST;
+    private var currentRequestLevel = 0;
 
     public function formatSection(level: Int, sectionLevel: Int, text: String): String {
         final hashes = StringTools.rpad('', '#', sectionLevel);
@@ -22,15 +23,19 @@ class PlainLoggerFormatter extends Base implements ILoggerFormatter {
             ? (hashes + ' ')
             : '';
         final textStr = Std.string(text);
-        this.parseCurrentRequest(level, textStr);
+        this.parseCurrentRequest(sectionLevel, textStr);
         return '${formatPrefix(level)}$prefix$textStr';
     }
 
-    private function parseCurrentRequest(level: Int, text: String): Void {
+    private function parseCurrentRequest(sectionLevel: Int, text: String): Void {
         final textStr = Std.string(text);
         if (StringTools.startsWith(textStr, REQUEST_PREFIX)) {
             final request = textStr.split('"')[1];
             this.currentRequest = (request != '') ? request : NO_REQUEST;
+            this.currentRequestLevel = sectionLevel;
+        } else if (sectionLevel <= this.currentRequestLevel) {
+            this.currentRequest = NO_REQUEST;
+            this.currentRequestLevel = 0;
         }
     }
 


### PR DESCRIPTION
When a second processor is run, the request id was not being reset to NO_REQUEST. Also, filenames were getting duplicated on each processor ('global.log', 'global.log.log', etc).