### PR TITLE
CUSDK-121: disable Logger beautifier.

### DIFF
--- a/connect/Flow.hx
+++ b/connect/Flow.hx
@@ -415,7 +415,8 @@ class Flow extends Base {
         final requestStr = Util.beautifyObject(
             this.model.toObject(),
             Env.getLogger().isCompact(),
-            Env.getLogger().getLevel() != Logger.LEVEL_DEBUG);
+            Env.getLogger().getLevel() != Logger.LEVEL_DEBUG,
+            Env.getLogger().isBeautified());
         final dataStr = Std.string(this.data);
 
         Env.getLogger().openSection(Std.string(index + 1) + '. ' + step.description);
@@ -591,7 +592,8 @@ class Flow extends Base {
                     ? Util.beautifyObject(
                         diff,
                         Env.getLogger().isCompact(),
-                        false)
+                        false,
+                        Env.getLogger().isBeautified())
                     : request;
                 final requestTitle = (diff != null) ? 'Request (changes):' : 'Request:';
                 return '$requestTitle${fmt.formatCodeBlock(Env.getLogger().getLevel(),Std.string(requestStr), 'json')}';
@@ -650,7 +652,8 @@ class Flow extends Base {
                 return null;
             }
         }
-     */
+    */
+    
     private function getClassName():String {
         #if js
         final constructorName = js.Syntax.code("{0}.constructor.name", this);

--- a/connect/api/impl/ApiClientImpl.hx
+++ b/connect/api/impl/ApiClientImpl.hx
@@ -311,7 +311,8 @@ class ApiClientImpl extends Base implements IApiClient {
                 Util.beautify(
                     data,
                     Env.getLogger().isCompact(),
-                    Env.getLogger().getLevel() != Logger.LEVEL_DEBUG),
+                    Env.getLogger().getLevel() != Logger.LEVEL_DEBUG,
+                    Env.getLogger().isBeautified()),
                 'json');
             return '$prefix$block';
         } else {

--- a/connect/logger/Logger.hx
+++ b/connect/logger/Logger.hx
@@ -30,6 +30,7 @@ class Logger extends Base {
     private final maskedFields:Collection<String>;
     private final regexMaskingList:Collection<EReg>;
     private final compact:Bool;
+    private final beautify:Bool;
     private var defaultFilename:String;
 
     /**
@@ -45,6 +46,7 @@ class Logger extends Base {
         this.maskedFields = config.maskedFields_.copy();
         this.regexMaskingList = config.regexMaskingList_.copy();
         if (this.maskedFields.indexOf('Authorization') == -1) this.maskedFields.push('Authorization');
+        this.beautify = config.beautify_;
         this.compact = (this.level != LEVEL_DEBUG) ? config.compact_ : false;
         this.defaultFilename = null;
     }
@@ -60,6 +62,14 @@ class Logger extends Base {
      */
     public function getLevel():Int {
         return this.level;
+    }
+
+    /**
+     * @return Bool Whether the logs are written in beautified format (this is,
+     * for JSON objects use new lines and two space indentation).
+     */
+    public function isBeautified(): Bool {
+        return this.beautify;
     }
 
     /**

--- a/connect/logger/LoggerConfig.hx
+++ b/connect/logger/LoggerConfig.hx
@@ -23,6 +23,8 @@ class LoggerConfig extends Base {
     @:dox(hide)
     public var compact_(default, null):Bool;
     @:dox(hide)
+    public var beautify_(default, null):Bool;
+    @:dox(hide)
     public var regexMaskingList_:Collection<EReg>;
 
     private static final levelTranslation:Map<String, Int> = [
@@ -38,6 +40,7 @@ class LoggerConfig extends Base {
         this.handlers_ = new Collection<LoggerHandler>().push(new LoggerHandler(new PlainLoggerFormatter(), new FileLoggerWriter()));
         this.maskedFields_ = new Collection<String>();
         this.compact_ = false;
+        this.beautify_ = true;
         this.regexMaskingList_ = new Collection<EReg>();
         this.customHandlers = false;
     }
@@ -102,6 +105,17 @@ class LoggerConfig extends Base {
      */
     public function maskedFields(maskedFields:Collection<String>):LoggerConfig {
         this.maskedFields_ = maskedFields;
+        return this;
+    }
+
+    /**
+     * Set whether the logs must be written in beautified format (this is,
+     * for JSON objects use new lines and two space indentation).
+     * @param enable Whether beautified logging should be enabled (defaults to `true`).
+     * @return LoggerConfig `this` instance to support a fluent interface.
+     */
+    public function beautify(enable:Bool):LoggerConfig {
+        this.beautify_ = enable;
         return this;
     }
 

--- a/connect/util/Util.hx
+++ b/connect/util/Util.hx
@@ -29,11 +29,12 @@ class Util {
         If the text contains a JSON string representation, it returns it beautified using two space
         indentation. Otherwise, returns the string as-is. If `compact` is `true` and the text
         contains a JSON string representation, only the id is returned or a string with all the
-        fields if it does not have an id.
+        fields if it does not have an id. If `beautify` is `true`, the JSON is returned with
+        spacing and indentation.
     */
-    public static function beautify(text:String, compact:Bool, masked: Bool):String {
+    public static function beautify(text:String, compact:Bool, masked:Bool, beautify:Bool):String {
         try {
-            return beautifyObject(haxe.Json.parse(text), compact, masked);
+            return beautifyObject(haxe.Json.parse(text), compact, masked, beautify);
         } catch (ex:Dynamic) {
            return replaceStrSensitiveData(text,Env.getLogger().getRegExMaskingList());
         }
@@ -46,7 +47,8 @@ class Util {
         is returned or a string with all the fields if it does not have an id. If `compact` is
         false and `masked` is true, all fields in the mask list will be masked.
     */
-    public static function beautifyObject(obj:Dynamic, compact:Bool, masked:Bool):String {
+    public static function beautifyObject(obj:Dynamic, compact:Bool, masked:Bool, beautify:Bool):String {
+        final spacing = beautify ? '  ' : null;
         if (compact) {
             if (Type.typeof(obj) == TObject) {
                 // Json contains an object
@@ -65,10 +67,10 @@ class Util {
                         ? '{ ' + Reflect.fields(el).join(', ') + ' }'
                         : Std.string(el);
                 });
-                return haxe.Json.stringify(mapped, null, '  ');
+                return haxe.Json.stringify(mapped, null, spacing);
             }
         } else {
-            return haxe.Json.stringify(masked ? maskFields(obj) : obj, null, '  ');
+            return haxe.Json.stringify(masked ? maskFields(obj) : obj, null, spacing);
         }
     }
 

--- a/test/unit/LoggerTest.hx
+++ b/test/unit/LoggerTest.hx
@@ -73,7 +73,7 @@ class LoggerTest {
 
     @Test
     public function testMaskDataInObj() {
-        final maskedInfo = Util.beautify(dataTestMaskDataInObj, false, true);
+        final maskedInfo = Util.beautify(dataTestMaskDataInObj, false, true, false);
         final result = Helper.sortObject(Json.parse(maskedInfo));
         final expected = Helper.sortObject(Json.parse(resultTestMaskDataInObj));
         Assert.areEqual(Json.stringify(expected), Json.stringify(result));
@@ -81,7 +81,7 @@ class LoggerTest {
 
     @Test
     public function testMaskDataInList() {
-        final maskedList: Array<Dynamic> = Json.parse(Util.beautify(dataTestMaskDataInList, false, true));
+        final maskedList: Array<Dynamic> = Json.parse(Util.beautify(dataTestMaskDataInList, false, true, false));
         final expectedList: Array<Dynamic> = Json.parse(resultTestMaskDataInList);
         Assert.areEqual(expectedList.length, maskedList.length);
         for (i in 0...maskedList.length) {
@@ -93,13 +93,13 @@ class LoggerTest {
 
     @Test
     public function testMaskDataInText() {
-        final maskedInfo = Util.beautify(dataTestMaskDataInText, false, true);
+        final maskedInfo = Util.beautify(dataTestMaskDataInText, false, true, false);
         Assert.areEqual(resultTestMaskDataInText, maskedInfo);
     }
     
     @Test
     public function testMaskNoDataInText() {
-        final unMaskedInfo = Util.beautify(dataTestNoMaskDataInText,false,true);
+        final unMaskedInfo = Util.beautify(dataTestNoMaskDataInText, false, true, false);
         Assert.areEqual(dataTestNoMaskDataInText,unMaskedInfo);
     }
 }

--- a/test/unit/ModelTest.hx
+++ b/test/unit/ModelTest.hx
@@ -12,7 +12,7 @@ class ModelTest {
     public function testToObject() {
         final param = new Param();
         param.valueChoice = new Collection<String>().push('My choice');
-        final expected = '{\n  "value_choice": [\n    "My choice"\n  ]\n}';
-        Assert.areEqual(expected, Util.beautifyObject(param.toObject(), false, false));
+        final expected = '{"value_choice":["My choice"]}';
+        Assert.areEqual(expected, Util.beautifyObject(param.toObject(), false, false, false));
     }
 }


### PR DESCRIPTION
LoggerConfig now has a `beautify(enable:Bool)` method (which defaults to `true`), that will disable beautification of JSON data in log messages, allowing them to fit in a single line.