### PR TITLE
Cusdk 131 mask connect params

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os: linux
 dist: bionic
 language: haxe
-haxe: 4.1.3
+haxe: 4.1.4
 
 install:
 # Get SDK version

--- a/connect/logger/Logger.hx
+++ b/connect/logger/Logger.hx
@@ -28,6 +28,7 @@ class Logger extends Base {
     private final handlers:Collection<LoggerHandler>;
     private final sections:Array<LoggerSection>;
     private final maskedFields:Collection<String>;
+    private final maskedParams:Collection<String>;
     private final regexMaskingList:Collection<EReg>;
     private final compact:Bool;
     private final beautify:Bool;
@@ -44,6 +45,7 @@ class Logger extends Base {
         this.handlers = config.handlers_.copy();
         this.sections = [];
         this.maskedFields = config.maskedFields_.copy();
+        this.maskedParams = config.maskedParams_.copy();
         this.regexMaskingList = config.regexMaskingList_.copy();
         if (this.maskedFields.indexOf('Authorization') == -1) this.maskedFields.push('Authorization');
         this.beautify = config.beautify_;
@@ -213,11 +215,14 @@ class Logger extends Base {
         }
     }
 
-    /**
-     *  Returns a list of fields which should be masked in http requests or responses
-    **/
+    /** Returns a list of fields which should be masked in http requests or responses. **/
     public function getMaskedFields():Collection<String> {
         return this.maskedFields;
+    }
+
+    /** Returns a list of param ids whose value should be masked in logged requests. **/
+    public function getMaskedParams():Collection<String> {
+        return this.maskedParams;
     }
 
      /**

--- a/connect/logger/LoggerConfig.hx
+++ b/connect/logger/LoggerConfig.hx
@@ -21,11 +21,13 @@ class LoggerConfig extends Base {
     @:dox(hide)
     public var maskedFields_(default, null):Collection<String>;
     @:dox(hide)
+    public var maskedParams_(default, null):Collection<String>;
+    @:dox(hide)
+    public var regexMaskingList_:Collection<EReg>;
+    @:dox(hide)
     public var compact_(default, null):Bool;
     @:dox(hide)
     public var beautify_(default, null):Bool;
-    @:dox(hide)
-    public var regexMaskingList_:Collection<EReg>;
 
     private static final levelTranslation:Map<String, Int> = [
         'ERROR' => Logger.LEVEL_ERROR,
@@ -39,6 +41,7 @@ class LoggerConfig extends Base {
         this.level_ = Logger.LEVEL_INFO;
         this.handlers_ = new Collection<LoggerHandler>().push(new LoggerHandler(new PlainLoggerFormatter(), new FileLoggerWriter()));
         this.maskedFields_ = new Collection<String>();
+        this.maskedParams_ = new Collection<String>();
         this.compact_ = false;
         this.beautify_ = true;
         this.regexMaskingList_ = new Collection<EReg>();
@@ -105,6 +108,16 @@ class LoggerConfig extends Base {
      */
     public function maskedFields(maskedFields:Collection<String>):LoggerConfig {
         this.maskedFields_ = maskedFields;
+        return this;
+    }
+
+    /**
+     * Sets the id of the params whose value should be masked in the logs.
+     * @param maskedParams Collection of param ids (string).
+     * @return LoggerConfig `this` instance to support a fluent interface.
+     */
+    public function maskedParams(maskedParams:Collection<String>):LoggerConfig {
+        this.maskedParams_ = maskedParams;
         return this;
     }
 

--- a/connect/models/Param.hx
+++ b/connect/models/Param.hx
@@ -24,7 +24,7 @@ class Param extends IdModel {
     public var description: String;
 
 
-    /** Type of parameter. **/
+    /** Type of parameter. One of: text, dropdown, password, email, checkbox, subdomain, domain, phone, url, choice. **/
     public var type: String;
 
 

--- a/connect/util/Util.hx
+++ b/connect/util/Util.hx
@@ -110,7 +110,10 @@ class Util {
                 if (fieldName == 'params' && Std.is(value, Array)) {
                     for (param in cast(value, Array<Dynamic>)) {
                         if (Type.typeof(param) == TObject && Reflect.hasField(param, 'id') && Reflect.hasField(param, 'value')) {
-                            if (maskedParams.indexOf(Std.string(Reflect.field(param, 'id'))) != -1) {
+                            final isPassword = Reflect.hasField(param, 'type')
+                                ? (Reflect.field(param, 'type') == 'password')
+                                : false;
+                            if (maskedParams.indexOf(Std.string(Reflect.field(param, 'id'))) != -1 || isPassword) {
                                 final paramValue = Std.string(Reflect.field(param, 'value'));
                                 Reflect.setField(param, 'value', StringTools.lpad('', '*', paramValue.length));
                             }

--- a/test/unit/LoggerTest.hx
+++ b/test/unit/LoggerTest.hx
@@ -128,10 +128,9 @@ class LoggerTest {
             }
         }));
 
-        Assert.areEqual(
-            '{"asset":{"params":[{"id":"my_param","value":"********"},{"id":"other_param","value":"other_value"}]}}',
-            Util.beautify(request.toString(), false, true, false)
-        );
+        final expected = Helper.sortStringObject(AssetRequest, '{"asset":{"params":[{"id":"my_param","value":"********"},{"id":"other_param","value":"other_value"}]}}');
+        final result = Helper.sortStringObject(AssetRequest, Util.beautify(request.toString(), false, true, false));
+        Assert.areEqual(expected, result);
     }
 
     @Test
@@ -153,9 +152,8 @@ class LoggerTest {
             }
         }));
 
-        Assert.areEqual(
-            '{"asset":{"params":[{"type":"password","id":"one_param","value":"********"},{"id":"other_param","value":"other_value"}]}}',
-            Util.beautify(request.toString(), false, true, false)
-        );
+        final expected = Helper.sortStringObject(AssetRequest, '{"asset":{"params":[{"type":"password","id":"one_param","value":"********"},{"id":"other_param","value":"other_value"}]}}');
+        final result = Helper.sortStringObject(AssetRequest, Util.beautify(request.toString(), false, true, false));
+        Assert.areEqual(expected, result);
     }
 }

--- a/test/unit/LoggerTest.hx
+++ b/test/unit/LoggerTest.hx
@@ -133,4 +133,29 @@ class LoggerTest {
             Util.beautify(request.toString(), false, true, false)
         );
     }
+
+    @Test
+    public function testMaskPasswordParam() {
+        final request = Model.parse(AssetRequest, Json.stringify({
+            asset: {
+                params: [
+                    {
+                        id: 'one_param',
+                        value: 'my_value',
+                        type: 'password',
+                    },
+                    {
+                        id: 'other_param',
+                        value: 'other_value',
+                        type: null,
+                    }
+                ]
+            }
+        }));
+
+        Assert.areEqual(
+            '{"asset":{"params":[{"type":"password","id":"one_param","value":"********"},{"id":"other_param","value":"other_value"}]}}',
+            Util.beautify(request.toString(), false, true, false)
+        );
+    }
 }

--- a/test/unit/LoggerTest.hx
+++ b/test/unit/LoggerTest.hx
@@ -2,16 +2,18 @@
     This file is part of the Ingram Micro CloudBlue Connect SDK.
     Copyright (c) 2019 Ingram Micro. All Rights Reserved.
 */
-import test.util.ArrayLoggerWriter;
 import connect.logger.Logger;
 import connect.logger.LoggerHandler;
 import connect.logger.LoggerConfig;
 import connect.logger.MarkdownLoggerFormatter;
+import connect.models.AssetRequest;
+import connect.models.Model;
 import connect.Env;
 import connect.util.Collection;
 import connect.util.Util;
-import massive.munit.Assert;
 import haxe.Json;
+import massive.munit.Assert;
+import test.util.ArrayLoggerWriter;
 
 class LoggerTest {
     private static final dataTestMaskDataInObj:String = '{"apiKey":"123456","non_important_data": 1,"some_list":["a","b",{"username":"1"}],"smtp": {"user":"loguser","password":"pass"},"the_obj":{"a":"test"},"id_obj":{"id":"the id"}}';
@@ -24,6 +26,9 @@ class LoggerTest {
     private static final dataTestNoMaskDataInText:String = 'This is a testing string with no passwords and no users';
     private static final resultTestMaskDataInText:String = '********* *********&********* topSecret=*********,*********';
 
+    private static final MASKED_PARAM_ID = 'my_param';
+    private static final MASKED_PARAM_VALUE = 'my_value';
+
     @Before
     public function setup() {
         Env._reset();
@@ -34,6 +39,8 @@ class LoggerTest {
             .push("smtpUsername")
             .push("id_obj")
             .push("the_obj");
+        final maskedParams:Collection<String> = new Collection()
+            .push(MASKED_PARAM_ID);
         final maskingRegex:Collection<String> = new Collection()
             .push("(Bearer\\s[\\d|a-f]{8}-([\\d|a-f]{4}-){3}[\\d|a-f]{12})")
             .push("(password=[^\\&]*)")
@@ -43,6 +50,7 @@ class LoggerTest {
             .handlers(new Collection<LoggerHandler>()
                 .push(new LoggerHandler(new MarkdownLoggerFormatter(), new ArrayLoggerWriter())));
         loggerConfiguration.maskedFields(maskedFields);
+        loggerConfiguration.maskedParams(maskedParams);
         loggerConfiguration.regexMasks(maskingRegex);
         Env.initLogger(loggerConfiguration);
     }
@@ -101,5 +109,28 @@ class LoggerTest {
     public function testMaskNoDataInText() {
         final unMaskedInfo = Util.beautify(dataTestNoMaskDataInText, false, true, false);
         Assert.areEqual(dataTestNoMaskDataInText,unMaskedInfo);
+    }
+
+    @Test
+    public function testMaskParam() {
+        final request = Model.parse(AssetRequest, Json.stringify({
+            asset: {
+                params: [
+                    {
+                        id: MASKED_PARAM_ID,
+                        value: MASKED_PARAM_VALUE,
+                    },
+                    {
+                        id: 'other_param',
+                        value: 'other_value',
+                    }
+                ]
+            }
+        }));
+
+        Assert.areEqual(
+            '{"asset":{"params":[{"id":"my_param","value":"********"},{"id":"other_param","value":"other_value"}]}}',
+            Util.beautify(request.toString(), false, true, false)
+        );
     }
 }


### PR DESCRIPTION
Apart from LoggerConfig.maskedFields, which masks JSON objects based on key names, I have added LoggerConfig.maskedParams, which allows masking a param value based on the param id. Also, value of params of type "password" is automatically masked too.