### PR TITLE
Cusdk 130 update parameter

### DIFF
--- a/connect/Flow.hx
+++ b/connect/Flow.hx
@@ -654,29 +654,6 @@ class Flow extends Base {
         });
         return fmt.formatTable(Env.getLogger().getLevel(),dataCol);
     }
-
-    /*
-        private function getAssetRequestChanges(): AssetRequest {
-            if (this.getAssetRequest() != null) {
-                final originalModel = Json.parse(this.originalModelStr);
-                final diff = Util.createObjectDiff(this.model.toObject(), originalModel);
-                return connect.models.Model.parse(AssetRequest, Json.stringify(diff));
-            } else {
-                return null;
-            }
-        }
-
-
-        private function getTierConfigRequestChanges(): TierConfigRequest {
-            if (this.getTierConfigRequest() != null) {
-                final originalModel = Json.parse(this.originalModelStr);
-                final diff = Util.createObjectDiff(this.model.toObject(), originalModel);
-                return connect.models.Model.parse(TierConfigRequest, Json.stringify(diff));
-            } else {
-                return null;
-            }
-        }
-    */
     
     private function getClassName():String {
         #if js

--- a/connect/models/AssetRequest.hx
+++ b/connect/models/AssetRequest.hx
@@ -176,7 +176,7 @@ class AssetRequest extends IdModel {
         final params: Array<Dynamic> = (asset != null) ? Reflect.field(asset, 'params') : null;
         if (params != null) {
             Lambda.iter(params, function(p) {
-                if (!Reflect.hasField(p, 'value') && (!Reflect.hasField(p, 'value_error') || Reflect.field(p, 'value_error') == '')) {
+                if (!Reflect.hasField(p, 'value')) {
                     final value = this.asset.getParamById(Reflect.field(p, 'id')).value;
                     Reflect.setField(p, 'value', value);
                 }

--- a/connect/models/TierConfigRequest.hx
+++ b/connect/models/TierConfigRequest.hx
@@ -193,7 +193,7 @@ class TierConfigRequest extends IdModel {
             Reflect.deleteField(diff, 'configuration');
         }
         Lambda.iter(diff.params, function(p) {
-            if (!Reflect.hasField(p, 'value') && (!Reflect.hasField(p, 'value_error') || Reflect.field(p, 'value_error') == '')) {
+            if (!Reflect.hasField(p, 'value')) {
                 final id = Reflect.field(p, 'id');
                 final tcrValue = (hasTcrParams && this.getParamById(id) != null)
                     ? this.getParamById(id).value

--- a/test/unit/AssetRequestTest.hx
+++ b/test/unit/AssetRequestTest.hx
@@ -95,11 +95,11 @@ class AssetRequestTest {
         final request = AssetRequest.get('PR-5852-1608-0000');
         final updatedRequest = request.update(new Collection<Param>().push(param));
         Assert.isType(updatedRequest, AssetRequest);
-        Assert.areEqual(request.toString(), updatedRequest.toString());
+        Assert.areEqual(request, updatedRequest);
     }
 
     @Test
-    public function testUpdateValueError() {
+    public function testUpdateWithEmptyValueError() {
         final request = AssetRequest.get('PR-5852-1608-0000');
         final param = request.asset.getParamById('activationCode');
         param.valueError = '';
@@ -108,6 +108,18 @@ class AssetRequestTest {
         Assert.areNotEqual(updatedRequest, request);
         Assert.areEqual('value param', updatedRequest.asset.getParamById('activationCode').value);
         Assert.areEqual('', updatedRequest.asset.getParamById('activationCode').valueError);
+    }
+
+    @Test
+    public function testUpdateWithValueError() {
+        final request = AssetRequest.get('PR-5852-1608-0000');
+        final param = request.asset.getParamById('activationCode');
+        param.valueError = 'Changed';
+        final updatedRequest = request.update(null);
+        Assert.isType(updatedRequest, AssetRequest);
+        Assert.areNotEqual(updatedRequest, request);
+        Assert.areEqual('value param', updatedRequest.asset.getParamById('activationCode').value);
+        Assert.areEqual('Changed', updatedRequest.asset.getParamById('activationCode').valueError);
     }
 
     @Test

--- a/test/unit/TierConfigRequestTest.hx
+++ b/test/unit/TierConfigRequestTest.hx
@@ -106,12 +106,21 @@ class TierConfigRequestTest {
     }
 
     @Test
-    public function testUpdateWithValueError() {
+    public function testUpdateWithEmptyValueError() {
         final request = TierConfigRequest.get('TCR-000-000-000');
         request.configuration.getParamById('tc_param').valueError = '';
         final updatedRequest = request.update(null);
         Assert.areEqual('tc_param_value', updatedRequest.getParamById('tc_param').value);
         Assert.areEqual('', updatedRequest.getParamById('tc_param').valueError);
+    }
+
+    @Test
+    public function testUpdateWithValueError() {
+        final request = TierConfigRequest.get('TCR-000-000-000');
+        request.configuration.getParamById('tc_param').valueError = 'Changed';
+        final updatedRequest = request.update(null);
+        Assert.areEqual('tc_param_value', updatedRequest.getParamById('tc_param').value);
+        Assert.areEqual('Changed', updatedRequest.getParamById('tc_param').valueError);
     }
 
     @Test


### PR DESCRIPTION
When a request update does not contain a value field for a Param, the value is set to null in Connect, so an update has been made to always send the value of the param.