### PR TITLE
Cusdk 143 datetime crash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ before_script:
   - "./stuff/java_clone.sh"
 
 script:
-  - haxelib run munit test -neko -coverage
-  - haxelib run munit test -cs -java -js -php -python
+  - haxelib run munit test -php -coverage
+  - haxelib run munit test -cs -java -python
   - haxe package.hxml
   - haxe doc.hxml
 

--- a/connect/util/DateTime.hx
+++ b/connect/util/DateTime.hx
@@ -61,11 +61,11 @@ class DateTime {
         final timeSplit = (dateTimeSplit.length > 1)
             ? dateTimeSplit[1].split(':')
             : '00:00:00'.split(':');
-        final year = Std.parseInt(dateSplit[0]);
-        if (year == null) {
-            return null;
-        }
         try {
+            final year = Std.parseInt(dateSplit[0]);
+            if (year == null) {
+                return null;
+            }
             final month = (dateSplit.length > 1)
                 ? (Std.parseInt(dateSplit[1]) - 1)
                 : 0;

--- a/connect/util/DateTime.hx
+++ b/connect/util/DateTime.hx
@@ -65,20 +65,24 @@ class DateTime {
         if (year == null) {
             return null;
         }
-        final month = (dateSplit.length > 1)
-            ? (Std.parseInt(dateSplit[1]) - 1)
-            : 0;
-        final day = (dateSplit.length > 2)
-            ? Std.parseInt(dateSplit[2])
-            : 1;
-        final hour = Std.parseInt(timeSplit[0]);
-        final minute = (timeSplit.length > 1)
-            ? Std.parseInt(timeSplit[1])
-            : 0;
-        final second = (timeSplit.length > 2)
-            ? Std.parseInt(timeSplit[2])
-            : 0;
-        return new DateTime(year, month, day, hour, minute, second);
+        try {
+            final month = (dateSplit.length > 1)
+                ? (Std.parseInt(dateSplit[1]) - 1)
+                : 0;
+            final day = (dateSplit.length > 2)
+                ? Std.parseInt(dateSplit[2])
+                : 1;
+            final hour = Std.parseInt(timeSplit[0]);
+            final minute = (timeSplit.length > 1)
+                ? Std.parseInt(timeSplit[1])
+                : 0;
+            final second = (timeSplit.length > 2)
+                ? Std.parseInt(timeSplit[2])
+                : 0;
+            return new DateTime(year, month, day, hour, minute, second);
+        } catch (ex: Dynamic) {
+            return null;
+        }
     }
 
 


### PR DESCRIPTION
Fixed crash in DateTime.fromString when trying to parse some weirdly formed strings which do not contain a valid date.