### PR TITLE
CUSDK-136: Add Flow.setVolatileData

### DIFF
--- a/connect/Flow.hx
+++ b/connect/Flow.hx
@@ -415,6 +415,7 @@ class Flow extends Base implements FlowExecutorDelegate implements FlowStoreDele
     private function prepareRequest(request:IdModel):Bool {
         this.request = request;
         this.data = new Dictionary();
+        this.volatileData = new Dictionary();
         this.firstStep = 0;
         this.lastRequestState = new ProcessedRequestInfo(null, null);
         this.stepAttempt = 1;
@@ -498,6 +499,7 @@ class Flow extends Base implements FlowExecutorDelegate implements FlowStoreDele
     public function onLoad(request:IdModel, firstStep:Int, data:Dictionary, storageType:String, numAttempts:Int):Void {
         this.firstStep = firstStep;
         this.data = data;
+        this.volatileData = new Dictionary();
         this.stepAttempt = numAttempts;
         this.logger.writeLoadedStepData(firstStep, storageType);
     }
@@ -505,6 +507,7 @@ class Flow extends Base implements FlowExecutorDelegate implements FlowStoreDele
     public function onFailedLoad(request:IdModel):Void {
         this.firstStep = 0;
         this.data = new Dictionary();
+        this.volatileData = new Dictionary();
         this.stepAttempt = 1;
     }
 

--- a/connect/Flow.hx
+++ b/connect/Flow.hx
@@ -46,6 +46,7 @@ class Flow extends Base implements FlowExecutorDelegate implements FlowStoreDele
     private final store:FlowStore;
     private var request:IdModel;
     private var data:Dictionary;
+    private var volatileData:Dictionary;
     private var firstStep:Int;
     private var lastRequestState:ProcessedRequestInfo;
     private var stepAttempt:Int;
@@ -65,6 +66,7 @@ class Flow extends Base implements FlowExecutorDelegate implements FlowStoreDele
         this.store = new FlowStore(this);
         this.request = null;
         this.data = new Dictionary();
+        this.volatileData = new Dictionary();
         this.firstStep = 0;
         this.lastRequestState = null;
         this.stepAttempt = 0;
@@ -202,12 +204,31 @@ class Flow extends Base implements FlowExecutorDelegate implements FlowStoreDele
     }
 
     /**
-        Retrieves Flow data previously set with `setData`.
+        This method follows the same goal as `setData`, but the data established with
+        this method never gets saved in case processing fails. So this is ideal
+        for storing data that can be safely recomputed on next execution, and we do
+        not need to retrieve from saved data. If we store a value with both `setVolatileData`
+        and `setData`, then `getData` will retrieve the persistent version set with `setData`,
+        so be careful about that behaviour.
+    **/
+    public function setVolatileData(key:String, value:Dynamic):Flow {
+        this.volatileData.set(key, value);
+        return this;
+    }
+
+    /**
+        Retrieves Flow data previously set with `setData` or `setVolatileData`.
+        If the data has been set both as persistent as volatile, the persistent
+        version is obtained.
         @param key The name of the key that identifies the data to be obtained.
         @returns The value of the data, or `null` if the key does not exist.
     **/
     public function getData(key:String):Dynamic {
-        return this.data.get(key);
+        if (this.data.exists(key)) {
+            return this.data.get(key);
+        } else {
+            return this.volatileData.get(key);
+        }
     }
 
     /**
@@ -384,7 +405,7 @@ class Flow extends Base implements FlowExecutorDelegate implements FlowStoreDele
         this.logger.openRequestSection(request);
         if (this.prepareRequest(request) && this.processSetup()) {
             this.store.requestDidBegin(this.request);
-            this.executor.executeRequest(request, this.data, this.firstStep);
+            this.executor.executeRequest(request, this.firstStep);
         } else {
             this.logger.writeMigrationMessage(request);
         }

--- a/connect/Processor.hx
+++ b/connect/Processor.hx
@@ -40,10 +40,11 @@ import haxe.Constraints.Function;
     supported target languages.
 **/
 class Processor extends Base {
+    private var flows: Array<Flow>;
+    
     public function new() {
         this.flows = [];
     }
-
 
     /**
         Defines a flow of `this` Processor. Steps in the are executed sequentially by the Processor
@@ -58,7 +59,6 @@ class Processor extends Base {
         return this;
     }
 
-
     /**
         Processes all `AssetRequest` objects that match the given filters,
         executing in sequence all the flows defined for them.
@@ -69,7 +69,6 @@ class Processor extends Base {
     public function processAssetRequests(filters: Query): Void {
         run(AssetRequest, filters);
     }
-
 
     /**
         Processes all `Listing` objects that match the given filters,
@@ -82,7 +81,6 @@ class Processor extends Base {
         run(Listing, filters);
     }
 
-
     /**
         Processes all `TierConfigRequest` objects that match the given filters,
         executing in sequence all the flows defined for them.
@@ -94,7 +92,6 @@ class Processor extends Base {
         run(TierConfigRequest, filters);
     }
 
-
     /**
         Processes all `UsageFile` objects that match the given filters,
         executing in sequence all the flows defined for them.
@@ -105,10 +102,6 @@ class Processor extends Base {
     public function processUsageFiles(filters: Query): Void {
         run(UsageFile, filters);
     }
-
-
-    private var flows: Array<Flow>;
-
 
     private function run<T>(modelClass: Class<T>, filters: Query): Void {
         // On some platforms, a string is received as modelClass, so obtain the real class from it

--- a/connect/Processor.hx
+++ b/connect/Processor.hx
@@ -13,7 +13,6 @@ import connect.models.UsageFile;
 import connect.util.DateTime;
 import haxe.Constraints.Function;
 
-
 /**
     The Processor helps automating the task of processing a list of requests, and updates the log
     automatically with all operations performed.
@@ -40,15 +39,35 @@ import haxe.Constraints.Function;
     supported target languages.
 **/
 class Processor extends Base {
+    private var flowClasses: Array<Class<Flow>>;
+    private var flows: Array<Flow>;
+
     public function new() {
+        this.flowClasses = [];
         this.flows = [];
     }
-
 
     /**
         Defines a flow of `this` Processor. Steps in the are executed sequentially by the Processor
         when its `run` method is invoked for all the requests that return `true` in the filter
         function passed in the creation of the flow.
+
+        @param flow The class that will be used to instantiate the processor.
+        It requires a constructor without arguments.
+        @returns `this` Processor, so calls to this method can be chained.
+    **/
+    public function flowClass(flowClass: Class<Flow>): Processor {
+        this.flowClasses.push(flowClass);
+        return this;
+    }
+
+    /**
+        Defines a flow of `this` Processor. Steps in the are executed sequentially by the Processor
+        when its `run` method is invoked for all the requests that return `true` in the filter
+        function passed in the creation of the flow.
+
+        NOTE: The `flowClass` method is the preferred way to define flows. This method is maintained
+        for backwards compatibility only.
 
         @param flow The flow to add to the processor.
         @returns `this` Processor, so calls to this method can be chained.
@@ -57,7 +76,6 @@ class Processor extends Base {
         this.flows.push(flow);
         return this;
     }
-
 
     /**
         Processes all `AssetRequest` objects that match the given filters,
@@ -70,7 +88,6 @@ class Processor extends Base {
         run(AssetRequest, filters);
     }
 
-
     /**
         Processes all `Listing` objects that match the given filters,
         executing in sequence all the flows defined for them.
@@ -81,7 +98,6 @@ class Processor extends Base {
     public function processListings(filters: Query): Void {
         run(Listing, filters);
     }
-
 
     /**
         Processes all `TierConfigRequest` objects that match the given filters,
@@ -94,7 +110,6 @@ class Processor extends Base {
         run(TierConfigRequest, filters);
     }
 
-
     /**
         Processes all `UsageFile` objects that match the given filters,
         executing in sequence all the flows defined for them.
@@ -105,10 +120,6 @@ class Processor extends Base {
     public function processUsageFiles(filters: Query): Void {
         run(UsageFile, filters);
     }
-
-
-    private var flows: Array<Flow>;
-
 
     private function run<T>(modelClass: Class<T>, filters: Query): Void {
         // On some platforms, a string is received as modelClass, so obtain the real class from it
@@ -129,10 +140,9 @@ class Processor extends Base {
             final list = Reflect.callMethod(modelClass, listMethod, [filters]);
             Env.getLogger().closeSection();
             
-            // Call each flow
-            for (flow in flows) {
-                flow._run(list);
-            }
+            // Run each flow
+            Lambda.iter(this.flowClasses, cls -> Type.createInstance(cls, [])._run(list));
+            Lambda.iter(this.flows, flow -> flow._run(list));
         } catch (ex: Dynamic) {
             // Catch exception when listing
             Env.getLogger().writeCodeBlock(Logger.LEVEL_ERROR, Std.string(ex), '');

--- a/connect/flow/FlowExecutor.hx
+++ b/connect/flow/FlowExecutor.hx
@@ -25,22 +25,22 @@ class FlowExecutor {
         this.steps.push(new Step(description, func));
     }
 
-    public function executeRequest(request:IdModel, data:Dictionary, firstIndex: Int):Void {
+    public function executeRequest(request:IdModel, firstIndex: Int):Void {
         final steps = [for (i in firstIndex...this.steps.length) this.steps[i]];
-        this.processSteps(request, steps, data, firstIndex);
+        this.processSteps(request, steps, firstIndex);
     }
 
-    private function processSteps(request:IdModel, steps:Array<Step>, data:Dictionary, firstIndex:Int):Void {
+    private function processSteps(request:IdModel, steps:Array<Step>, firstIndex:Int):Void {
         Lambda.foldi(steps, function(step, shouldContinue, index) {
             if (shouldContinue) {
-                return processStep(request, step, data, index + firstIndex);
+                return processStep(request, step, index + firstIndex);
             } else {
                 return false;
             }
         }, true);
     }
 
-    private function processStep(request:IdModel, step:Step, data:Dictionary, index:Int):Bool {
+    private function processStep(request:IdModel, step:Step, index:Int):Bool {
         if (this.delegate != null) {
             this.delegate.onStepBegin(request, step, index);
         }


### PR DESCRIPTION
In case you need some data in the Flow not to be stored when processing fails, Flow now has the setVolatileData method, which allows exactly for that: define request-specific data which won't be stored.