### PR TITLE
CUSDK-158: Abort status is not reset after finishing a request.

### DIFF
--- a/Connect.hx
+++ b/Connect.hx
@@ -209,6 +209,7 @@ class Connect {
 
             if (pkg == 'connect') {
                 file.writeString('SYNCREQUEST_PATH = \'connect.autogen.connect_api_impl_ApiClientImpl.syncRequest\'' + EOL + EOL);
+                file.writeString('SYNCREQUESTWITHLOGGER_PATH = \'connect.autogen.connect_api_impl_ApiClientImpl.syncRequestWithLogger\'' + EOL + EOL);
             }
 
             // Write __all__

--- a/connect/Flow.hx
+++ b/connect/Flow.hx
@@ -444,6 +444,7 @@ class Flow extends Base implements FlowExecutorDelegate implements FlowStoreDele
         this.logger.openSetupSection();
         var ok = true;
         try {
+            this.executor.reset();
             this.setup();
         } catch (ex:Dynamic) {
             final exStr = getExceptionMessage(ex);

--- a/connect/flow/FlowExecutor.hx
+++ b/connect/flow/FlowExecutor.hx
@@ -25,6 +25,11 @@ class FlowExecutor {
         this.steps.push(new Step(description, func));
     }
 
+    public function reset():Void {
+        this.abortRequested = false;
+        this.abortMessage = null;
+    }
+
     public function executeRequest(request:IdModel, firstIndex: Int):Void {
         final steps = [for (i in firstIndex...this.steps.length) this.steps[i]];
         this.processSteps(request, steps, firstIndex);


### PR DESCRIPTION
If you abort a request in the Flow's setup() method, the next request will begin with aborted status in the setup() method, and won't reset it until the first step. This fixes the issue by making sure that every time the setup() method executes, status from previous request is reset.