### PR TITLE
CUSDK-155: Add request prefix to all logs when a flow is running.

### DIFF
--- a/connect/Flow.hx
+++ b/connect/Flow.hx
@@ -5,6 +5,7 @@
 
 package connect;
 
+import connect.api.ConnectHelper;
 import connect.flow.FlowStoreDelegate;
 import connect.flow.FlowStore;
 import connect.flow.ProcessedRequestInfo;
@@ -75,7 +76,9 @@ class Flow extends Base implements FlowExecutorDelegate implements FlowStoreDele
     private function getClassName():String {
         #if js
         final constructorName = js.Syntax.code("{0}.constructor.name", this);
-        final className = (constructorName != 'Object') ? constructorName : Type.getClassName(Type.getClass(this));
+        final className = (constructorName != 'Object')
+            ? constructorName
+            : Type.getClassName(Type.getClass(this));
         return className;
         #elseif php
         return php.Syntax.code("get_class({0})", this);
@@ -418,6 +421,7 @@ class Flow extends Base implements FlowExecutorDelegate implements FlowStoreDele
     }
 
     private function runRequest(request:IdModel):Void {
+        ConnectHelper.setLogger(Env.getLoggerForRequest(request));
         this.logger.openRequestSection(request);
         if (this.prepareRequest(request) && this.processSetup()) {
             this.store.requestDidBegin(this.request);
@@ -426,6 +430,7 @@ class Flow extends Base implements FlowExecutorDelegate implements FlowStoreDele
             this.logger.writeMigrationMessage(request);
         }
         this.logger.closeRequestSection();
+        ConnectHelper.setLogger(Env.getLogger());
     }
 
     private function prepareRequest(request:IdModel):Bool {

--- a/connect/api/ConnectHelper.hx
+++ b/connect/api/ConnectHelper.hx
@@ -5,12 +5,20 @@
 package connect.api;
 
 import connect.Env;
+import connect.logger.Logger;
 import connect.util.Blob;
 import connect.util.Dictionary;
 import connect.models.IdModel;
 
 @:dox(hide)
 class ConnectHelper {
+    private static var logger = Env.getLogger();
+
+    /* Sets the logger that will be usef in all subsequent calls */
+    public static function setLogger(logger:Logger):Void {
+        ConnectHelper.logger = logger;
+    }
+
     /**
         Get a Connect resource if 'id' is specified, or a list of reosurces otherwise.
 
@@ -18,13 +26,15 @@ class ConnectHelper {
         @param id Optional id of the resource to get.
         @param suffix Optional path suffix (i.e. "approve").
         @param params Query params.
+        @param rqlParams Indicates whether params should be sent as SQL (query params otherwise).
+        @param logLevel Log level to use.
         @returns A string with the response.
         @throws String if the request fails.
     **/
-    public static function get(resource: String, ?id: String, ?suffix: String,
-            ?params: Query, rqlParams: Bool = false, ?currentRequest: IdModel, ?logLevel: Int): String {
+    public static function get(resource:String, ?id:String, ?suffix:String,
+            ?params:Query, rqlParams:Bool = false, ?logLevel:Int): String {
         return checkResponse(connectSyncRequest('GET', parsePath(resource, id, suffix),
-            getHeaders(), params, rqlParams, null, null, null, null, currentRequest, logLevel));
+            getHeaders(), params, rqlParams, null, null, null, null, logLevel));
     }
 
     /**
@@ -32,14 +42,16 @@ class ConnectHelper {
 
         @param resource Resource path (e.g. "requests" for the Fulfillment API).
         @param id Id of the resource to put data on.
+        @param suffix Optional path suffix (i.e. "approve").
         @param body The body to put (normally the modified resource).
+        @param logLevel Log level to use.
         @returns A string with the response.
         @throws String if the request fails.
     **/
-    public static function put(resource: String, id: String, suffix: String, body: String,
-            ?currentRequest: IdModel, ?logLevel: Int): String {
+    public static function put(resource:String, id:String, suffix:String,
+            body:String, ?logLevel:Int):String {
         return checkResponse(connectSyncRequest('PUT', parsePath(resource, id, suffix),
-            getHeaders(), null, false, body, null, null, null, currentRequest, logLevel));
+            getHeaders(), null, false, body, null, null, null, logLevel));
     }
 
     /**
@@ -49,12 +61,14 @@ class ConnectHelper {
         @param id Optional id of the resource to post data to.
         @param suffix Optional path suffix (i.e. "approve").
         @param body The body to post.
+        @param logLevel Log level to use.
         @returns An object.
         @throws String if the request fails.
     **/
-    public static function post(resource: String, ?id: String, ?suffix: String, ?body: String, ?currentRequest: IdModel, ?logLevel: Int): String {
+    public static function post(resource:String, ?id:String, ?suffix:String,
+            ?body:String, ?logLevel:Int):String {
         return checkResponse(connectSyncRequest('POST', parsePath(resource, id, suffix),
-            getHeaders(), null, false, body, null, null, null, currentRequest, logLevel));
+            getHeaders(), null, false, body, null, null, null, logLevel));
     }
 
     /**
@@ -66,13 +80,14 @@ class ConnectHelper {
         @param argname Argument name in the request.
         @param filename Name of the file to send.
         @param contents Contents of the file.
+        @param logLevel Log level to use.
         @returns An object.
         @throws String if the request fails.
     **/
-    public static function postFile(resource: String, ?id: String, ?suffix: String,
-            fileArg: String, fileName: String, fileContents: Blob, ?currentRequest: Null<IdModel> = null, ?logLevel: Null<Int> = null): Dynamic {
+    public static function postFile(resource:String, ?id:String, ?suffix:String,
+            fileArg:String, fileName:String, fileContents:Blob, ?logLevel:Int):Dynamic {
         return checkResponse(connectSyncRequest('POST', parsePath(resource, id, suffix),
-            getHeaders(false), null, false, null, fileArg, fileName, fileContents, currentRequest, logLevel));
+            getHeaders(false), null, false, null, fileArg, fileName, fileContents, logLevel));
     }
 
     /**
@@ -81,36 +96,34 @@ class ConnectHelper {
         @param resource Resource path (e.g. "requests" for the Fulfillment API).
         @param id Id of the resource to delete.
         @param suffix Optional path suffix (i.e. "delete").
+        @param logLevel Log level to use.
         @returns A string with the response.
         @throws String if the request fails.
     **/
-    public static function delete(resource: String, id: String, ?suffix: String, ?currentRequest: Null<IdModel> = null, ?logLevel: Null<Int> = null): String {
+    public static function delete(resource:String, id:String, ?suffix:String, ?logLevel:Int):String {
         return checkResponse(connectSyncRequest('DELETE', parsePath(resource, id, suffix), getHeaders(),
-            null, false, null, null, null, null, currentRequest, logLevel));
+            null, false, null, null, null, null, logLevel));
     }
 
-    private static function connectSyncRequest(method: String, path: String, headers: Dictionary,
-            params: Null<Query>, rqlParams: Bool, data: Null<String>,
-            fileArg: Null<String>, fileName: Null<String>, fileContent: Null<Blob>,
-            currentRequest: Null<IdModel>, logLevel: Null<Int>) : Response {
+    private static function connectSyncRequest(method:String, path:String, headers:Dictionary,
+            params:Null<Query>, rqlParams:Bool, data:Null<String>,
+            fileArg:Null<String>, fileName:Null<String>, fileContent:Null<Blob>,
+            logLevel:Null<Int>):Response {
         final paramsStr = (params != null)
-            ? (rqlParams) ? params.toString() : params.toPlain()
+            ? (rqlParams ? params.toString() : params.toPlain())
             : '';
         final url = Env.getConfig().getApiUrl() + path + paramsStr;
-        var logger = currentRequest != null
-            ? Env.getLoggerForRequest(currentRequest)
-            : Env.getLoggerForRequest(null);
-        return Env.getApiClient().syncRequestWithLogger(method, url, headers, data, fileArg, fileName, fileContent,
-            null, logger, logLevel);
+        return Env.getApiClient().syncRequestWithLogger(method, url, headers, data,
+            fileArg, fileName, fileContent, null, logger, logLevel);
     }
 
-    private static function parsePath(resource: String, ?id: String, ?suffix: String): String {
+    private static function parsePath(resource:String, ?id:String, ?suffix:String):String {
         return resource
             + (id != null && id != '' ? '/' + id : '')
             + (suffix != null && suffix != '' ? '/' + suffix : '');
     }
 
-    private static function getHeaders(addContentType: Bool = true): Dictionary {
+    private static function getHeaders(addContentType:Bool = true):Dictionary {
         final headers = new Dictionary();
         headers.set('Authorization', Env.getConfig().getApiKey());
         if (addContentType) {
@@ -121,7 +134,7 @@ class ConnectHelper {
         return headers;
     }
 
-    private static function checkResponse(response: Response): String {
+    private static function checkResponse(response:Response):String {
         if (response.status < 400) {
             return response.text;
         } else {

--- a/connect/api/FulfillmentApi.hx
+++ b/connect/api/FulfillmentApi.hx
@@ -16,7 +16,7 @@ class FulfillmentApi extends Base {
     }
 
     public function listRequests(filters: Query): String {
-        return ConnectHelper.get(REQUESTS_PATH, null, null, filters, Logger.LEVEL_DEBUG);
+        return ConnectHelper.get(REQUESTS_PATH, null, null, filters, false, Logger.LEVEL_DEBUG);
     }
 
     public function getRequest(id: String): String {
@@ -27,21 +27,21 @@ class FulfillmentApi extends Base {
         return ConnectHelper.post(REQUESTS_PATH, null, null, body);    
     }
 
-    public function updateRequest(id: String, request: String, currentRequest: Null<IdModel>): String {
-        return ConnectHelper.put(REQUESTS_PATH, id, null, request, currentRequest);
+    public function updateRequest(id: String, request: String): String {
+        return ConnectHelper.put(REQUESTS_PATH, id, null, request);
     }
 
-    public function changeRequestStatus(id: String, status: String, data: String, currentRequest: Null<IdModel>): String {
-        return ConnectHelper.post(REQUESTS_PATH, id, status, data, currentRequest);
+    public function changeRequestStatus(id: String, status: String, data: String): String {
+        return ConnectHelper.post(REQUESTS_PATH, id, status, data);
     }
 
-    public function assignRequest(id: String, assignee: String, currentRequest: Null<IdModel>): String {
-        return ConnectHelper.post(REQUESTS_PATH, id, 'assign/' + assignee, null, currentRequest);
+    public function assignRequest(id: String, assignee: String): String {
+        return ConnectHelper.post(REQUESTS_PATH, id, 'assign/' + assignee);
     }
 
-    public function renderTemplate(id: String, request_id: String): String {
+    public function renderTemplate(id: String, requestId: String): String {
         return ConnectHelper.get(TEMPLATES_PATH, id, 'render',
-            new Query().equal('request_id', request_id));
+            new Query().equal('request_id', requestId));
     }
 
     public function listAssets(filters: Query): String {
@@ -52,7 +52,7 @@ class FulfillmentApi extends Base {
         return ConnectHelper.get(ASSETS_PATH, id);
     }
 
-    public function getAssetRequests(id: String, currentRequest: Null<IdModel>): String {
+    public function getAssetRequests(id: String): String {
         return ConnectHelper.get(ASSETS_PATH, id, 'requests');
     }
 }

--- a/connect/api/GeneralApi.hx
+++ b/connect/api/GeneralApi.hx
@@ -17,7 +17,7 @@ class GeneralApi extends Base {
     }
 
     public function listAccounts(filters: Query): String {
-        return ConnectHelper.get(ACCOUNTS_PATH, null, null, filters, Logger.LEVEL_DEBUG);
+        return ConnectHelper.get(ACCOUNTS_PATH, null, null, filters, false, Logger.LEVEL_DEBUG);
     }
 
     public function createAccount(): String {
@@ -29,27 +29,27 @@ class GeneralApi extends Base {
     }
 
     public function listAccountUsers(id: String): String {
-        return ConnectHelper.get(ACCOUNTS_PATH, id, 'users', Logger.LEVEL_DEBUG);
+        return ConnectHelper.get(ACCOUNTS_PATH, id, 'users', null, false, Logger.LEVEL_DEBUG);
     }
 
     public function getAccountUser(id: String, userId: String): String {
         return ConnectHelper.get(ACCOUNTS_PATH, id, 'users/${userId}');
     }
 
-    public function listConversations(filters: Query, request: Null<IdModel>): String {
-        return ConnectHelper.get(CONVERSATIONS_PATH, null, null, filters, request, Logger.LEVEL_DEBUG);
+    public function listConversations(filters: Query): String {
+        return ConnectHelper.get(CONVERSATIONS_PATH, null, null, filters, false, Logger.LEVEL_DEBUG);
     }
 
-    public function createConversation(data: String, request: Null<IdModel>): String {
+    public function createConversation(data: String): String {
         return ConnectHelper.post(CONVERSATIONS_PATH, null, null, data, Logger.LEVEL_DEBUG);
     }
 
-    public function getConversation(id: String, request:Null<IdModel>): String {
-        return ConnectHelper.get(CONVERSATIONS_PATH, id, request, Logger.LEVEL_DEBUG);
+    public function getConversation(id: String): String {
+        return ConnectHelper.get(CONVERSATIONS_PATH, id, null, null, false, Logger.LEVEL_DEBUG);
     }
 
-    public function createConversationMessage(id: String, data: String, request:Null<IdModel>): String {
-        return ConnectHelper.post(CONVERSATIONS_PATH, id, 'messages', data, request, Logger.LEVEL_DEBUG);
+    public function createConversationMessage(id: String, data: String): String {
+        return ConnectHelper.post(CONVERSATIONS_PATH, id, 'messages', data, Logger.LEVEL_DEBUG);
     }
 
     public function listProducts(filters: Query): String {
@@ -61,7 +61,7 @@ class GeneralApi extends Base {
     }
 
     public function listProductActions(id: String, filters: Query): String {
-        return ConnectHelper.get(PRODUCTS_PATH, id, 'actions', filters, Logger.LEVEL_DEBUG);
+        return ConnectHelper.get(PRODUCTS_PATH, id, 'actions', filters, false, Logger.LEVEL_DEBUG);
     }
 
     public function getProductAction(id: String, actionId: String): String {
@@ -69,8 +69,8 @@ class GeneralApi extends Base {
     }
 
     public function getProductActionLink(id: String, actionId: String): String {
-        final response = haxe.Json.parse(ConnectHelper
-            .get(PRODUCTS_PATH, id, 'actions/${actionId}/actionLink'));
+        final response = haxe.Json.parse(
+            ConnectHelper.get(PRODUCTS_PATH, id, 'actions/${actionId}/actionLink'));
         return response.link;
     }
 
@@ -79,11 +79,11 @@ class GeneralApi extends Base {
     }
 
     public function listProductItems(id: String, filters: Query): String {
-        return ConnectHelper.get(PRODUCTS_PATH, id, 'items', filters, Logger.LEVEL_DEBUG);
+        return ConnectHelper.get(PRODUCTS_PATH, id, 'items', filters, false, Logger.LEVEL_DEBUG);
     }
 
     public function listProductParameters(id: String, filters: Query): String {
-        return ConnectHelper.get(PRODUCTS_PATH, id, 'parameters', filters, Logger.LEVEL_DEBUG);
+        return ConnectHelper.get(PRODUCTS_PATH, id, 'parameters', filters, false, Logger.LEVEL_DEBUG);
     }
 
     public function getProductParameter(id: String, paramId: String): String {
@@ -157,11 +157,11 @@ class GeneralApi extends Base {
     }
 
     public function listProductAgreements(id: String, filters: Query): String {
-        return ConnectHelper.get(PRODUCTS_PATH, id, 'agreements', filters, Logger.LEVEL_DEBUG);
+        return ConnectHelper.get(PRODUCTS_PATH, id, 'agreements', filters, false, Logger.LEVEL_DEBUG);
     }
 
     public function listProductMedia(id: String, filters: Query): String {
-        return ConnectHelper.get(PRODUCTS_PATH, id, 'media', filters, Logger.LEVEL_DEBUG);
+        return ConnectHelper.get(PRODUCTS_PATH, id, 'media', filters, false, Logger.LEVEL_DEBUG);
     }
 
     public function createProductMedia(id: String): String {
@@ -181,7 +181,7 @@ class GeneralApi extends Base {
     }
 
     public function listCategories(filters: Query): String {
-        return ConnectHelper.get(CATEGORIES_PATH, null, null, filters, Logger.LEVEL_DEBUG);
+        return ConnectHelper.get(CATEGORIES_PATH, null, null, filters, false, Logger.LEVEL_DEBUG);
     }
 
     public function getCategory(id: String): String {

--- a/connect/api/MarketplaceApi.hx
+++ b/connect/api/MarketplaceApi.hx
@@ -18,7 +18,7 @@ class MarketplaceApi {
     }
 
     public function listAgreements(filters: Query): String {
-        return ConnectHelper.get(AGREEMENTS_PATH, null, null, filters, Logger.LEVEL_DEBUG);
+        return ConnectHelper.get(AGREEMENTS_PATH, null, null, filters, false, Logger.LEVEL_DEBUG);
     }
 
     public function createAgreement(body: String): String {
@@ -38,7 +38,7 @@ class MarketplaceApi {
     }
 
     public function listAgreementVersions(id: String): String {
-        return ConnectHelper.get(AGREEMENTS_PATH, id, 'versions');
+        return ConnectHelper.get(AGREEMENTS_PATH, id, 'versions', null, false, Logger.LEVEL_DEBUG);
     }
 
     public function newAgreementVersion(id: String, body: String): String {
@@ -54,7 +54,7 @@ class MarketplaceApi {
     }
 
     public function listAgreementSubAgreements(id: String): String {
-        return ConnectHelper.get(AGREEMENTS_PATH, id, AGREEMENTS_PATH);
+        return ConnectHelper.get(AGREEMENTS_PATH, id, AGREEMENTS_PATH, null, false, Logger.LEVEL_DEBUG);
     }
 
     public function createAgreementSubAgreement(id: String, body: String): String {
@@ -62,19 +62,19 @@ class MarketplaceApi {
     }
 
     public function listListings(filters: Query): String {
-        return ConnectHelper.get(LISTINGS_PATH, null, null, filters);
+        return ConnectHelper.get(LISTINGS_PATH, null, null, filters, false, Logger.LEVEL_DEBUG);
     }
 
     public function getListing(id: String): String {
         return ConnectHelper.get(LISTINGS_PATH, id);
     }
 
-    public function putListing(id: String, body: String, currentRequest: Null<IdModel>): String {
-        return ConnectHelper.put(LISTINGS_PATH, id, null, body, currentRequest);
+    public function putListing(id: String, body: String): String {
+        return ConnectHelper.put(LISTINGS_PATH, id, null, body);
     }
 
     public function listListingRequests(filters: Query): String {
-        return ConnectHelper.get(LISTINGREQUESTS_PATH, null, null, filters);
+        return ConnectHelper.get(LISTINGREQUESTS_PATH, null, null, filters, false, Logger.LEVEL_DEBUG);
     }
 
     public function getListingRequest(id: String): String {
@@ -114,7 +114,7 @@ class MarketplaceApi {
     }
 
     public function listMarketplaces(filters: Query): String {
-        return ConnectHelper.get(MARKETPLACES_PATH, null, null, filters);
+        return ConnectHelper.get(MARKETPLACES_PATH, null, null, filters, false, Logger.LEVEL_DEBUG);
     }
 
     public function createMarketplace(body: String): String {

--- a/connect/api/TierApi.hx
+++ b/connect/api/TierApi.hx
@@ -27,32 +27,32 @@ class TierApi extends Base {
         return ConnectHelper.get(TCR_PATH, id);
     }
 
-    public function updateTierConfigRequest(id: String, tcr: String, currentRequest: Null<IdModel>): String {
-        return ConnectHelper.put(TCR_PATH, id, null, tcr, currentRequest);
+    public function updateTierConfigRequest(id: String, tcr: String): String {
+        return ConnectHelper.put(TCR_PATH, id, null, tcr);
     }
 
-    public function pendTierConfigRequest(id: String, currentRequest: Null<IdModel>): Void {
-        ConnectHelper.post(TCR_PATH, id, 'pend', currentRequest);
+    public function pendTierConfigRequest(id: String): Void {
+        ConnectHelper.post(TCR_PATH, id, 'pend');
     }
 
-    public function inquireTierConfigRequest(id: String, currentRequest: Null<IdModel>): Void {
-        ConnectHelper.post(TCR_PATH, id, 'inquire', currentRequest);
+    public function inquireTierConfigRequest(id: String): Void {
+        ConnectHelper.post(TCR_PATH, id, 'inquire');
     }
 
-    public function approveTierConfigRequest(id: String, data: String, currentRequest: Null<IdModel>): String {
-        return ConnectHelper.post(TCR_PATH, id, 'approve', data, currentRequest);
+    public function approveTierConfigRequest(id: String, data: String): String {
+        return ConnectHelper.post(TCR_PATH, id, 'approve', data);
     }
 
-    public function failTierConfigRequest(id: String, data: String, currentRequest: Null<IdModel>): Void {
-        ConnectHelper.post(TCR_PATH, id, 'fail', data, currentRequest);
+    public function failTierConfigRequest(id: String, data: String): Void {
+        ConnectHelper.post(TCR_PATH, id, 'fail', data);
     }
 
-    public function assignTierConfigRequest(id: String, currentRequest: Null<IdModel>): Void {
-        ConnectHelper.post(TCR_PATH, id, 'assign', currentRequest);
+    public function assignTierConfigRequest(id: String): Void {
+        ConnectHelper.post(TCR_PATH, id, 'assign');
     }
 
-    public function unassignTierConfigRequest(id: String, currentRequest: Null<IdModel>): Void {
-        ConnectHelper.post(TCR_PATH, id, 'unassign', currentRequest);
+    public function unassignTierConfigRequest(id: String): Void {
+        ConnectHelper.post(TCR_PATH, id, 'unassign');
     }
 
     public function listTierAccounts(filters: Query): String {

--- a/connect/api/UsageApi.hx
+++ b/connect/api/UsageApi.hx
@@ -20,70 +20,68 @@ class UsageApi extends Base {
         return ConnectHelper.get(USAGE_FILES_PATH, null, null, filters, true, Logger.LEVEL_DEBUG);
     }
 
-    public function createUsageFile(body: String, currentRequest: Null<IdModel>): String {
-        return ConnectHelper.post(USAGE_FILES_PATH, null, null, body, currentRequest);
+    public function createUsageFile(body: String): String {
+        return ConnectHelper.post(USAGE_FILES_PATH, null, null, body);
     }
 
     public function getUsageFile(id: String): String {
         return ConnectHelper.get(USAGE_FILES_PATH, id);
     }
 
-    public function updateUsageFile(id: String, body: String, currentRequest: Null<IdModel>): String {
-        return ConnectHelper.put(USAGE_FILES_PATH, id, null, body, currentRequest);
+    public function updateUsageFile(id: String, body: String): String {
+        return ConnectHelper.put(USAGE_FILES_PATH, id, null, body);
     }
 
-    public function deleteUsageFile(id: String, currentRequest: Null<IdModel>): Void {
-        ConnectHelper.post(USAGE_FILES_PATH, id, 'delete', currentRequest);
+    public function deleteUsageFile(id: String): Void {
+        ConnectHelper.post(USAGE_FILES_PATH, id, 'delete');
     }
 
-    public function uploadUsageFile(id: String, file: Blob, currentRequest: Null<IdModel>): String {
+    public function uploadUsageFile(id: String, file: Blob): String {
         return ConnectHelper.postFile(
             USAGE_FILES_PATH,
             id,
             'upload',
             'usage_file',
             'usage_file.xlsx',
-            file,
-            currentRequest
+            file
         );
     }
 
-    public function submitUsageFileAction(id: String, currentRequest: Null<IdModel>): String {
-        return ConnectHelper.post(USAGE_FILES_PATH, id, 'submit', currentRequest);
+    public function submitUsageFileAction(id: String): String {
+        return ConnectHelper.post(USAGE_FILES_PATH, id, 'submit');
     }
 
-    public function acceptUsageFileAction(id: String, note: String, currentRequest: Null<IdModel>): String {
+    public function acceptUsageFileAction(id: String, note: String): String {
         return ConnectHelper.post(USAGE_FILES_PATH, id, 'accept',
-            haxe.Json.stringify({acceptance_note: note}), currentRequest);
+            haxe.Json.stringify({acceptance_note: note}));
     }
 
-    public function rejectUsageFileAction(id: String, note: String, currentRequest: Null<IdModel>): String {
+    public function rejectUsageFileAction(id: String, note: String): String {
         return ConnectHelper.post(USAGE_FILES_PATH, id, 'reject',
-            haxe.Json.stringify({rejection_note: note}), currentRequest);
+            haxe.Json.stringify({rejection_note: note}));
     }
 
-    public function closeUsageFileAction(id: String, currentRequest: Null<IdModel>): String {
-        return ConnectHelper.post(USAGE_FILES_PATH, id, 'close', currentRequest);
+    public function closeUsageFileAction(id: String): String {
+        return ConnectHelper.post(USAGE_FILES_PATH, id, 'close');
     }
 
-    public function getProductSpecificUsageFileTemplate(productId: String, currentRequest: Null<IdModel>): String {
-        return ConnectHelper.get(USAGE_PRODUCTS_PATH, productId, 'template', currentRequest);
+    public function getProductSpecificUsageFileTemplate(productId: String): String {
+        return ConnectHelper.get(USAGE_PRODUCTS_PATH, productId, 'template');
     }
 
-    public function uploadReconciliationFileFromProvider(id: String, file: Blob, currentRequest: Null<IdModel>): String {
+    public function uploadReconciliationFileFromProvider(id: String, file: Blob): String {
         return ConnectHelper.postFile(
             USAGE_FILES_PATH,
             id,
             'reconciliation',
             'reconciliation_file',
             'reconciliation_file.xlsx',
-            file,
-            currentRequest
+            file
         );
     }
 
-    public function reprocessProcessedFile(id: String, currentRequest: Null<IdModel>): String {
-        return ConnectHelper.post(USAGE_FILES_PATH, id, 'reprocess', currentRequest);
+    public function reprocessProcessedFile(id: String): String {
+        return ConnectHelper.post(USAGE_FILES_PATH, id, 'reprocess');
     }
 
     public function listUsageRecords(filters: Query): String {

--- a/connect/api/impl/ApiClientImpl.hx
+++ b/connect/api/impl/ApiClientImpl.hx
@@ -17,13 +17,13 @@ import haxe.io.BytesInput;
 
 class ApiClientImpl extends Base implements IApiClient {
     public function syncRequest(method: String, url: String, headers: Dictionary, body: String,
-        fileArg: String, fileName: String, fileContent: Blob, certificate:String) : Response {
-            return this.syncRequestWithLogger(method, url, headers, body,
-                fileArg, fileName, fileContent, certificate, Env.getLogger(), null);
-        }
+            fileArg: String, fileName: String, fileContent: Blob, certificate: String): Response {
+        return this.syncRequestWithLogger(method, url, headers, body,
+            fileArg, fileName, fileContent, certificate, null, null);
+    }
 
     public function syncRequestWithLogger(method: String, url: String, headers: Dictionary, body: String,
-            fileArg: String, fileName: String, fileContent: Blob, certificate:String, logger:Logger, logLevel: Null<Int>) : Response {
+            fileArg: String, fileName: String, fileContent: Blob, certificate: String, logger: Null<Logger>, logLevel: Null<Int>): Response {
     #if cs
         final response = syncRequestCs(method, url, headers, body, fileArg, fileName, fileContent, certificate);
     #elseif js
@@ -35,12 +35,16 @@ class ApiClientImpl extends Base implements IApiClient {
     #else
         final response = syncRequestStd(method, url, headers, body, fileArg, fileName, fileContent, certificate);
     #end
-
-        if(logLevel == null){
-            logLevel = (response.status >= 400 || response.status == -1)
-            ? Logger.LEVEL_ERROR
-            : Logger.LEVEL_INFO;
+        if (logger == null) {
+            logger = Env.getLogger();
         }
+
+        if (logLevel == null) {
+            logLevel = (response.status >= 400 || response.status == -1)
+                ? Logger.LEVEL_ERROR
+                : Logger.LEVEL_INFO;
+        }
+
         logRequest(logLevel, method, url, headers, body, response, logger);
 
         if (response.status != -1) {
@@ -50,9 +54,7 @@ class ApiClientImpl extends Base implements IApiClient {
         }
     }
 
-
     public function new() {}
-
 
 #if cs
     private static function syncRequestCs(method: String, url: String, headers: Dictionary, body: String,
@@ -117,7 +119,6 @@ class ApiClientImpl extends Base implements IApiClient {
         }
     }
 
-
 #elseif js
     private static function syncRequestJs(method: String, url: String, headers: Dictionary, body: String,
             fileArg: String, fileName: String, fileContent: Blob, certificate:String) : Response {
@@ -153,7 +154,6 @@ class ApiClientImpl extends Base implements IApiClient {
 
         return new Response(xhr.status, xhr.responseText, xhr.response);
     }
-
 
 #elseif use_tink
     private static function syncRequestTink(method: String, url: String, headers: Dictionary, body: String,
@@ -204,7 +204,6 @@ class ApiClientImpl extends Base implements IApiClient {
         return response;
     }
 
-
 #elseif python
     private static function syncRequestPython(method: String, url: String, headers: Dictionary, body: String,
             fileArg: String, fileName: String, fileContent: Blob, certificate: String) : Response {
@@ -215,7 +214,6 @@ class ApiClientImpl extends Base implements IApiClient {
             return new Response(-1, Std.string(ex), null);
         }
     }
-
 
 #else
     public function syncRequestStd(method: String, url: String, headers: Dictionary, body: String,
@@ -259,7 +257,6 @@ class ApiClientImpl extends Base implements IApiClient {
     }
 #end
 
-
     private static function logRequest(level: Int, method: String, url: String,
             headers: Dictionary, body: String, response: Response, ?logger:Null<Logger> = null): Void {
         final firstMessage = 'Http ${method.toUpperCase()} request to ${url}';
@@ -286,7 +283,6 @@ class ApiClientImpl extends Base implements IApiClient {
         }
     }
 
-
     private static function getHeadersTable(headers: Dictionary, fmt: ILoggerFormatter): String {
         final fixedHeaders = (Env.getLogger().getLevel() == Logger.LEVEL_DEBUG)
             ? headers
@@ -304,11 +300,9 @@ class ApiClientImpl extends Base implements IApiClient {
         return fmt.formatTable(Env.getLogger().getLevel(),headersCol);
     }
 
-
     private static function maskHeaders(headers: Dictionary): Dictionary {
         return Dictionary.fromObject(Util.maskFields(headers.toObject()));
     }
-
 
     private static function getFormattedData(data: String, title: String, fmt: ILoggerFormatter)
             : String {
@@ -331,7 +325,6 @@ class ApiClientImpl extends Base implements IApiClient {
             return '$title: $fixedBody';
         }
     }
-
 
 #if js
     private static inline final _JS_CODE = 'var Url=require("url"),spawn=require("child_process").spawn,fs=require("fs");global.XMLHttpRequest = function(){"use strict";var S,w,N=this,v=require("http"),g=require("https"),T={},s=!1,C={"User-Agent":"node-XMLHttpRequest",Accept:"*/*"},D={},O={},r=["accept-charset","accept-encoding","access-control-request-headers","access-control-request-method","connection","content-length","content-transfer-encoding","cookie","cookie2","date","expect","host","keep-alive","origin","referer","te","trailer","transfer-encoding","upgrade","via"],o=["TRACE","TRACK","CONNECT"],R=!1,q=!1,n={};this.UNSENT=0,this.OPENED=1,this.HEADERS_RECEIVED=2,this.LOADING=3,this.DONE=4,this.readyState=this.UNSENT,this.onreadystatechange=null,this.responseText="",this.responseXML="",this.status=null,this.statusText=null,this.withCredentials=!1;this.open=function(e,t,s,r,n){if(this.abort(),q=!1,!function(e){return e&&-1===o.indexOf(e)}(e))throw new Error("SecurityError: Request method not allowed");T={method:e,url:t.toString(),async:"boolean"!=typeof s||s,user:r||null,password:n||null},L(this.OPENED)},this.setDisableHeaderCheck=function(e){s=e},this.setRequestHeader=function(e,t){if(this.readyState!==this.OPENED)throw new Error("INVALID_STATE_ERR: setRequestHeader can only be called when state is OPEN");if(function(e){return s||e&&-1===r.indexOf(e.toLowerCase())}(e)){if(R)throw new Error("INVALID_STATE_ERR: send flag is true");e=O[e.toLowerCase()]||e,O[e.toLowerCase()]=e,D[e]=D[e]?D[e]+", "+t:t}else console.warn(\'Refused to set unsafe header \\"\'+e+\'\\"\')},this.getResponseHeader=function(e){return"string"==typeof e&&this.readyState>this.OPENED&&w&&w.headers&&w.headers[e.toLowerCase()]&&!q?w.headers[e.toLowerCase()]:null},this.getAllResponseHeaders=function(){if(this.readyState<this.HEADERS_RECEIVED||q)return"";var e="";for(var t in w.headers)"set-cookie"!==t&&"set-cookie2"!==t&&(e+=t+": "+w.headers[t]+"\\r\\n");return e.substr(0,e.length-2)},this.getRequestHeader=function(e){return"string"==typeof e&&O[e.toLowerCase()]?D[O[e.toLowerCase()]]:""},this.send=function(e){if(this.readyState!==this.OPENED)throw new Error("INVALID_STATE_ERR: connection must be opened before send() is called");if(R)throw new Error("INVALID_STATE_ERR: send has already been called");var n,t=!1,s=!1,r=Url.parse(T.url);switch(r.protocol){case"https:":t=!0;case"http:":n=r.hostname;break;case"file:":s=!0;break;case void 0:case null:case"":n="localhost";break;default:throw new Error("Protocol not supported.")}if(s){if("GET"!==T.method)throw new Error("XMLHttpRequest: Only GET method is supported");if(T.async)fs.readFile(r.pathname,"utf8",function(e,t){e?N.handleError(e):(N.status=200,N.responseText=t,L(N.DONE))});else try{this.responseText=fs.readFileSync(r.pathname,"utf8"),this.status=200,L(N.DONE)}catch(e){this.handleError(e)} }else{var o=r.port||(t?443:80),a=r.pathname+(r.search?r.search:"");for(var i in C)O[i.toLowerCase()]||(D[i]=C[i]);if(D.Host=n,"["===r.host[0]&&(D.Host="["+D.Host+"]"),t&&443===o||80===o||(D.Host+=":"+r.port),T.user){void 0===T.password&&(T.password="");var h=new Buffer(T.user+":"+T.password);D.Authorization="Basic "+h.toString("base64")}"GET"===T.method||"HEAD"===T.method?e=null:e?(D["Content-Length"]=Buffer.isBuffer(e)?e.length:Buffer.byteLength(e),this.getRequestHeader("Content-Type")||(D["Content-Type"]="text/plain;charset=UTF-8")):"POST"===T.method&&(D["Content-Length"]=0);var d={host:n,port:o,path:a,method:T.method,headers:D,agent:!1,withCredentials:N.withCredentials};if(q=!1,T.async){var u=t?g.request:v.request;R=!0,N.dispatchEvent("readystatechange");var c=function(e){N.handleError(e)};S=u(d,function e(t){if(301!==(w=t).statusCode&&302!==w.statusCode&&303!==w.statusCode&&307!==w.statusCode)w.setEncoding("utf8"),L(N.HEADERS_RECEIVED),N.status=w.statusCode,w.on("data",function(e){e&&(N.responseText+=e),R&&L(N.LOADING)}),w.on("end",function(){R&&(L(N.DONE),R=!1)}),w.on("error",function(e){N.handleError(e)});else{T.url=w.headers.location;var s=Url.parse(T.url);n=s.hostname;var r={hostname:s.hostname,port:s.port,path:s.path,method:303===w.statusCode?"GET":T.method,headers:D,withCredentials:N.withCredentials};(S=u(r,e).on("error",c)).end()} }).on("error",c),e&&S.write(e),S.end(),N.dispatchEvent("loadstart")}else{var f=".node-xmlhttprequest-content-"+process.pid,l=".node-xmlhttprequest-sync-"+process.pid;fs.writeFileSync(l,"","utf8");for(var p="var http = require(\'http\'), https = require(\'https\'), fs = require(\'fs\');var doRequest = http"+(t?"s":"")+".request;var options = "+JSON.stringify(d)+";var responseText = \'\';var req = doRequest(options, function(response) {response.setEncoding(\'utf8\');response.on(\'data\', function(chunk) {  responseText += chunk;});response.on(\'end\', function() {fs.writeFileSync(\'"+f+"\', JSON.stringify({err: null, data: {statusCode: response.statusCode, headers: response.headers, text: responseText} }), \'utf8\');fs.unlinkSync(\'"+l+"\');});response.on(\'error\', function(error) {fs.writeFileSync(\'"+f+"\', JSON.stringify({err: error}), \'utf8\');fs.unlinkSync(\'"+l+"\');});}).on(\'error\', function(error) {fs.writeFileSync(\'"+f+"\', JSON.stringify({err: error}), \'utf8\');fs.unlinkSync(\'"+l+"\');});"+(e?"req.write(\'"+JSON.stringify(e).slice(1,-1).replace(/\'/g,"\\\'")+"\');":"")+"req.end();",E=spawn(process.argv[0],["-e",p]);fs.existsSync(l););var y=JSON.parse(fs.readFileSync(f,"utf8"));E.stdin.end(),fs.unlinkSync(f),y.err?N.handleError(y.err):(w=y.data,N.status=y.data.statusCode,N.responseText=y.data.text,L(N.DONE))} } },this.handleError=function(e){this.status=0,this.statusText=e,this.responseText=e.stack,q=!0,L(this.DONE),this.dispatchEvent("error")},this.abort=function(){S&&(S.abort(),S=null),D=C,this.status=0,this.responseText="",this.responseXML="",q=!0,this.readyState===this.UNSENT||this.readyState===this.OPENED&&!R||this.readyState===this.DONE||(R=!1,L(this.DONE)),this.readyState=this.UNSENT,this.dispatchEvent("abort")},this.addEventListener=function(e,t){e in n||(n[e]=[]),n[e].push(t)},this.removeEventListener=function(e,t){e in n&&(n[e]=n[e].filter(function(e){return e!==t}))},this.dispatchEvent=function(e){if("function"==typeof N["on"+e]&&N["on"+e](),e in n)for(var t=0,s=n[e].length;t<s;t++)n[e][t].call(N)};var L=function(e){e!=N.LOADING&&N.readyState===e||(N.readyState=e,(T.async||N.readyState<N.OPENED||N.readyState===N.DONE)&&N.dispatchEvent("readystatechange"),N.readyState!==N.DONE||q||(N.dispatchEvent("load"),N.dispatchEvent("loadend")))} };';

--- a/connect/models/Asset.hx
+++ b/connect/models/Asset.hx
@@ -132,7 +132,7 @@ class Asset extends IdModel {
 
     /** @returns A collection with all the requests for the `this` Asset. **/
     public function getRequests(): Collection<AssetRequest> {
-        final requests = Env.getFulfillmentApi().getAssetRequests(this.id, this);
+        final requests = Env.getFulfillmentApi().getAssetRequests(this.id);
         return Model.parseArray(AssetRequest, requests);
     }
 

--- a/connect/models/AssetRequest.hx
+++ b/connect/models/AssetRequest.hx
@@ -156,7 +156,7 @@ class AssetRequest extends IdModel {
             if (hasModifiedFields) {
                 final request = Env.getFulfillmentApi().updateRequest(
                     this.id,
-                    haxe.Json.stringify(addValueToParams(diff)),this);
+                    haxe.Json.stringify(addValueToParams(diff)));
                 return Model.parse(AssetRequest, request);
             } else {
                 return this;
@@ -165,7 +165,7 @@ class AssetRequest extends IdModel {
             if (params.length() > 0) {
                 Env.getFulfillmentApi().updateRequest(
                     this.id,
-                    '{"asset":{"params":${params.toString()}}}',this);
+                    '{"asset":{"params":${params.toString()}}}');
             }
             return this;
         }
@@ -199,7 +199,7 @@ class AssetRequest extends IdModel {
         final request = Env.getFulfillmentApi().changeRequestStatus(
             this.id,
             'approve',
-            haxe.Json.stringify({template_id: id}), this
+            haxe.Json.stringify({template_id: id})
         );
         this._updateConversation('Request approved using template $id.');
         return Model.parse(AssetRequest, request);
@@ -219,7 +219,7 @@ class AssetRequest extends IdModel {
         final request = Env.getFulfillmentApi().changeRequestStatus(
             this.id,
             'approve',
-            haxe.Json.stringify({activation_tile: text}), this
+            haxe.Json.stringify({activation_tile: text})
         );
         this._updateConversation('Request approved using custom activation tile.');
         return Model.parse(AssetRequest, request);
@@ -238,7 +238,7 @@ class AssetRequest extends IdModel {
         final request = Env.getFulfillmentApi().changeRequestStatus(
             this.id,
             'fail',
-            haxe.Json.stringify({reason: reason}), this
+            haxe.Json.stringify({reason: reason})
         );
         this._updateConversation('Request failed: $reason.');
         return Model.parse(AssetRequest, request);
@@ -261,7 +261,7 @@ class AssetRequest extends IdModel {
         final request = Env.getFulfillmentApi().changeRequestStatus(
             this.id,
             'inquire',
-            haxe.Json.stringify(body), this
+            haxe.Json.stringify(body)
         );
         this._updateConversation('Request inquired.');
         return Model.parse(AssetRequest, request);
@@ -277,11 +277,7 @@ class AssetRequest extends IdModel {
         the updated status.
     **/
     public function pend(): AssetRequest {
-        final request = Env.getFulfillmentApi().changeRequestStatus(
-            this.id,
-            'pend',
-            haxe.Json.stringify({}), this
-        );
+        final request = Env.getFulfillmentApi().changeRequestStatus(this.id, 'pend', '{}');
         this._updateConversation('Request pended.');
         return Model.parse(AssetRequest, request);
     }
@@ -293,11 +289,7 @@ class AssetRequest extends IdModel {
         the updated assignee.
     **/
     public function assign(assigneeId: String): AssetRequest {
-        final request = Env.getFulfillmentApi().assignRequest(
-            this.id,
-            assigneeId,
-            this
-        );
+        final request = Env.getFulfillmentApi().assignRequest(this.id, assigneeId);
         this._updateConversation('Request assigned to $assigneeId.');
         return Model.parse(AssetRequest, request);
     }
@@ -313,10 +305,10 @@ class AssetRequest extends IdModel {
 
     /** @returns The Conversation assigned to `this` AssetRequest, or `null` if there is none. **/
     public function getConversation(): Conversation {
-        final convs = Conversation.listForRequest(new Query().equal('instance_id', this.id), this);
+        final convs = Conversation.list(new Query().equal('instance_id', this.id));
         final conv = (convs.length() > 0) ? convs.get(0) : null;
         if  (conv != null && conv.id != null && conv.id != '') {
-            return Conversation.getForRequest(conv.id, this);
+            return Conversation.get(conv.id);
         } else {
             return null;
         }
@@ -327,7 +319,7 @@ class AssetRequest extends IdModel {
         final conversation = this.getConversation();
         if (conversation != null) {
             try {
-                conversation.createMessageForRequest(message, this);
+                conversation.createMessage(message);
             } catch (ex: Dynamic) {
                 Env.getLogger().write(
                     connect.logger.Logger.LEVEL_ERROR,

--- a/connect/models/Conversation.hx
+++ b/connect/models/Conversation.hx
@@ -36,16 +36,7 @@ class Conversation extends IdModel {
         @returns A collection of Conversations.
     **/
     public static function list(filters: Query) : Collection<Conversation> {
-        return listForRequest(filters, null);
-    }
-
-    /**
-        Lists conversations, passing the current request so it can be used when logging.
-
-        @returns A collection of Conversations.
-    **/
-    public static function listForRequest(filters: Query, request: Null<IdModel>) : Collection<Conversation> {
-        final convs = Env.getGeneralApi().listConversations(filters, request);
+        final convs = Env.getGeneralApi().listConversations(filters);
         return Model.parseArray(Conversation, convs);
     }
 
@@ -56,37 +47,17 @@ class Conversation extends IdModel {
         @returns The created Conversation.
     **/
     public static function create(instanceId: String, topic: String): Conversation {
-        return createForRequest(instanceId, topic, null);
-    }
-
-    /**
-        Creates a new conversation, linked to the given `instanceId`, with the specified `topic`, and logs to
-        the given `request` log.
-
-        @returns The created Conversation.
-    **/
-    public static function createForRequest(instanceId: String, topic: String, request: Null<IdModel>): Conversation {
         final conv = Env.getGeneralApi().createConversation(haxe.Json.stringify({
             instance_id: instanceId,
             topic: topic,
-        }), request);
+        }));
         return Model.parse(Conversation, conv);
     }
 
     /** @returns The Conversation with the given id, or `null` if it was not found. **/
     public static function get(id: String): Conversation {
-        return getForRequest(id, null);
-    }
-
-    /**
-        Same as `get`, but also gets a `request` so information can be written to the correct
-        log.
-
-        @returns The Conversation with the given id, or `null` if it was not found.
-    **/
-    public static function getForRequest(id: String, request: Null<IdModel>): Conversation {
         try {
-            final conv = Env.getGeneralApi().getConversation(id, request);
+            final conv = Env.getGeneralApi().getConversation(id);
             return Model.parse(Conversation, conv);
         } catch (ex: Dynamic) {
             return null;
@@ -101,21 +72,9 @@ class Conversation extends IdModel {
         the same as this one.
     **/
     public function createMessage(text: String): Message {
-        return createMessageForRequest(text, null);
-    }
-
-    /**
-        Creates a new message in `this` Conversation with the given `text`, as long as the text
-        is not the same as the one in the last `Message`. Logs the information to the given
-        `request`'s log.
-
-        @returns The created `Message`, or `null` if the last message in the `Conversation` is
-        the same as this one.
-    **/
-    public function createMessageForRequest(text: String, request: Null<IdModel>): Message {
         final msg = Env.getGeneralApi().createConversationMessage(
             this.id,
-            haxe.Json.stringify({ text: text }), request);
+            haxe.Json.stringify({ text: text }));
         final message = Model.parse(Message, msg);
         if (this.messages == null) {
             this.messages = new Collection<Message>();

--- a/connect/models/Listing.hx
+++ b/connect/models/Listing.hx
@@ -98,7 +98,7 @@ class Listing extends IdModel {
         if (hasModifiedFields) {
             final listing = Env.getMarketplaceApi().putListing(
                 this.id,
-                haxe.Json.stringify(diff),this);
+                haxe.Json.stringify(diff));
             return Model.parse(Listing, listing);
         } else {
             return this;

--- a/connect/models/TierConfigRequest.hx
+++ b/connect/models/TierConfigRequest.hx
@@ -159,7 +159,7 @@ class TierConfigRequest extends IdModel {
             if (hasModifiedFields) {
                 final request = Env.getTierApi().updateTierConfigRequest(
                     this.id,
-                    prepareUpdateBody(diff), this);
+                    prepareUpdateBody(diff));
                 return Model.parse(TierConfigRequest, request);
             } else {
                 return this;
@@ -168,7 +168,7 @@ class TierConfigRequest extends IdModel {
             if (params.length() > 0) {
                 Env.getTierApi().updateTierConfigRequest(
                     this.id,
-                    '{"params":${params.toString()}}', this);
+                    '{"params":${params.toString()}}');
             }
             return this;
         }
@@ -232,7 +232,7 @@ class TierConfigRequest extends IdModel {
     **/
     public function approveByTemplate(id: String): Bool {
         try {
-            Env.getTierApi().approveTierConfigRequest(this.id, haxe.Json.stringify({template: {id: id}}), this);
+            Env.getTierApi().approveTierConfigRequest(this.id, haxe.Json.stringify({template: {id: id}}));
             return true;
         } catch (ex: Dynamic) {
             return false;
@@ -248,7 +248,7 @@ class TierConfigRequest extends IdModel {
     **/
     public function approveByTile(text: String): TierConfigRequest {
         try {
-            final tcr = Env.getTierApi().approveTierConfigRequest(this.id, haxe.Json.stringify({activation_tile: text}), this);
+            final tcr = Env.getTierApi().approveTierConfigRequest(this.id, haxe.Json.stringify({activation_tile: text}));
             return Model.parse(TierConfigRequest, tcr);
         } catch (ex: Dynamic) {
             return null;
@@ -263,7 +263,7 @@ class TierConfigRequest extends IdModel {
     **/
     public function fail(reason: String): Bool {
         try {
-            Env.getTierApi().failTierConfigRequest(this.id, haxe.Json.stringify({reason: reason}), this);
+            Env.getTierApi().failTierConfigRequest(this.id, haxe.Json.stringify({reason: reason}));
             return true;
         } catch (ex: Dynamic) {
             return false;
@@ -278,7 +278,7 @@ class TierConfigRequest extends IdModel {
     **/
     public function inquire(): Bool {
         try {
-            Env.getTierApi().inquireTierConfigRequest(this.id, this);
+            Env.getTierApi().inquireTierConfigRequest(this.id);
             return true;
         } catch (ex: Dynamic) {
             return false;
@@ -293,7 +293,7 @@ class TierConfigRequest extends IdModel {
     **/
     public function pend(): Bool {
         try {
-            Env.getTierApi().pendTierConfigRequest(this.id, this);
+            Env.getTierApi().pendTierConfigRequest(this.id);
             return true;
         } catch (ex: Dynamic) {
             return false;
@@ -305,7 +305,7 @@ class TierConfigRequest extends IdModel {
     **/
     public function assign(): Bool {
         try {
-            Env.getTierApi().assignTierConfigRequest(this.id, this);
+            Env.getTierApi().assignTierConfigRequest(this.id);
             return true;
         } catch (ex: Dynamic) {
             return false;
@@ -317,7 +317,7 @@ class TierConfigRequest extends IdModel {
     **/
     public function unassign(): Bool {
         try {
-            Env.getTierApi().unassignTierConfigRequest(this.id, this);
+            Env.getTierApi().unassignTierConfigRequest(this.id);
             return true;
         } catch (ex: Dynamic) {
             return false;

--- a/connect/models/UsageFile.hx
+++ b/connect/models/UsageFile.hx
@@ -143,7 +143,7 @@ class UsageFile extends IdModel {
     **/
     public function register(): UsageFile {
         try {
-            final newUsageFile = Env.getUsageApi().createUsageFile(this.toString(),this);
+            final newUsageFile = Env.getUsageApi().createUsageFile(this.toString());
             return Model.parse(UsageFile, newUsageFile);
         } catch (ex: Dynamic) {
             return null;
@@ -170,7 +170,7 @@ class UsageFile extends IdModel {
         if (hasModifiedFields) {
             final usageFile = Env.getUsageApi().updateUsageFile(
                 this.id,
-                haxe.Json.stringify(diff), this);
+                haxe.Json.stringify(diff));
             return Model.parse(UsageFile, usageFile);
         } else {
             return this;
@@ -180,7 +180,7 @@ class UsageFile extends IdModel {
     /** Deletes `this` UsageFile in the server. **/
     public function delete(): Bool {
         try {
-            Env.getUsageApi().deleteUsageFile(this.id, this);
+            Env.getUsageApi().deleteUsageFile(this.id);
             return true;
         } catch (ex: Dynamic) {
             return false;
@@ -317,7 +317,7 @@ class UsageFile extends IdModel {
         @returns The UsageFile returned from the server.
     **/
     public function upload(content: Blob): UsageFile {
-        final usageFile = Env.getUsageApi().uploadUsageFile(this.id, content, this);
+        final usageFile = Env.getUsageApi().uploadUsageFile(this.id, content);
         return Model.parse(UsageFile, usageFile);
     }
 
@@ -327,7 +327,7 @@ class UsageFile extends IdModel {
         @returns The UsageFile returned from the server.
     **/
     public function submit(): UsageFile {
-        final usageFile = Env.getUsageApi().submitUsageFileAction(this.id, this);
+        final usageFile = Env.getUsageApi().submitUsageFileAction(this.id);
         return Model.parse(UsageFile, usageFile);
     }
 
@@ -337,7 +337,7 @@ class UsageFile extends IdModel {
         @returns The UsageFile returned from the server.
     **/
     public function accept(note: String): UsageFile {
-        final usageFile = Env.getUsageApi().acceptUsageFileAction(this.id, note, this);
+        final usageFile = Env.getUsageApi().acceptUsageFileAction(this.id, note);
         return Model.parse(UsageFile, usageFile);
     }
 
@@ -347,7 +347,7 @@ class UsageFile extends IdModel {
         @returns The UsageFile returned from the server.
     **/
     public function reject(note: String): UsageFile {
-        final usageFile = Env.getUsageApi().rejectUsageFileAction(this.id, note, this);
+        final usageFile = Env.getUsageApi().rejectUsageFileAction(this.id, note);
         return Model.parse(UsageFile, usageFile);
     }
 
@@ -357,7 +357,7 @@ class UsageFile extends IdModel {
         @returns The UsageFile returned from the server.
     **/
     public function close(): UsageFile {
-        final usageFile = Env.getUsageApi().closeUsageFileAction(this.id, this);
+        final usageFile = Env.getUsageApi().closeUsageFileAction(this.id);
         return Model.parse(UsageFile, usageFile);
     }
 
@@ -378,7 +378,7 @@ class UsageFile extends IdModel {
         Gets the product specific file template URL for `this` UsageFile.
     **/
     public function getTemplateLink(): String {
-        final link = haxe.Json.parse(Env.getUsageApi().getProductSpecificUsageFileTemplate(this.id, this));
+        final link = haxe.Json.parse(Env.getUsageApi().getProductSpecificUsageFileTemplate(this.id));
         return link.template_link;
     }
 
@@ -389,7 +389,7 @@ class UsageFile extends IdModel {
         @returns The UsageFile returned from the server.
     **/
     public function uploadReconciliation(content: Blob): UsageFile {
-        final usageFile = Env.getUsageApi().uploadReconciliationFileFromProvider(this.id, content, this);
+        final usageFile = Env.getUsageApi().uploadReconciliationFileFromProvider(this.id, content);
         return Model.parse(UsageFile, usageFile);
     }
 
@@ -400,7 +400,7 @@ class UsageFile extends IdModel {
         @returns The UsageFile returned from the server.
     **/
     public function reprocess(): UsageFile {
-        final usageFile = Env.getUsageApi().reprocessProcessedFile(this.id, this);
+        final usageFile = Env.getUsageApi().reprocessProcessedFile(this.id);
         return Model.parse(UsageFile, usageFile);
     }
 }


### PR DESCRIPTION
When using a Flow, the requests performed by the flow itself have the correct prefix in the log, but other Connect calls you might perform (like Product.get) don't. Now, ConnectHelper is aware of the context where the flow is running (since the flow sets the correct logger for it every time a new request begins processing), so all calls will be correctly logged.