### PR TITLE
CUSDK-155: Fixed logger being automatically initialized on program start.

### DIFF
--- a/connect/Env.hx
+++ b/connect/Env.hx
@@ -4,8 +4,6 @@
 */
 package connect;
 
-import connect.logger.ILoggerFormatter;
-import connect.logger.LoggerHandler;
 import connect.api.IApiClient;
 import connect.api.FulfillmentApi;
 import connect.api.GeneralApi;

--- a/connect/api/ConnectHelper.hx
+++ b/connect/api/ConnectHelper.hx
@@ -8,15 +8,22 @@ import connect.Env;
 import connect.logger.Logger;
 import connect.util.Blob;
 import connect.util.Dictionary;
-import connect.models.IdModel;
 
 @:dox(hide)
 class ConnectHelper {
-    private static var logger = Env.getLogger();
+    private static var logger:Logger;
 
     /* Sets the logger that will be usef in all subsequent calls */
     public static function setLogger(logger:Logger):Void {
         ConnectHelper.logger = logger;
+    }
+
+    /* Gets the current logger */
+    public static function getLogger():Logger {
+        if (logger == null) {
+            logger = Env.getLogger();
+        }
+        return logger;
     }
 
     /**
@@ -114,7 +121,7 @@ class ConnectHelper {
             : '';
         final url = Env.getConfig().getApiUrl() + path + paramsStr;
         return Env.getApiClient().syncRequestWithLogger(method, url, headers, data,
-            fileArg, fileName, fileContent, null, logger, logLevel);
+            fileArg, fileName, fileContent, null, getLogger(), logLevel);
     }
 
     private static function parsePath(resource:String, ?id:String, ?suffix:String):String {


### PR DESCRIPTION
Storing the root logger in the ConnectHelper on startup causes the logger to be initialized, so any further attempts to init the logger will raise an exception. This defers the retrieval of the log on the ConnectHelper side until th efirst time it is actually used.