### PR TITLE
CUSDK-178: TierConfigRequest.update fix (v20 backport)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,9 @@ deploy:
   skip_cleanup: true
   keep_history: false
   on:
+    all_branches: true
     tags: true
-    branch: master
+    condition: $TRAVIS_BRANCH =~ ^master$|^release/.*$
 
 after_deploy:
 # Push Java code
@@ -76,5 +77,4 @@ after_deploy:
   - cd ../..
 
 after_script:
-# Push repository tag when in master branch
-  - python3 stuff/push_tag.py
+# Push repository tag when in master or release/* branches

--- a/connect/models/TierConfigRequest.hx
+++ b/connect/models/TierConfigRequest.hx
@@ -154,15 +154,20 @@ class TierConfigRequest extends IdModel {
     **/
     public function update(params: Collection<Param>): TierConfigRequest {
         if (params == null) {
-            final diff = this._toDiff();
-            final hasModifiedFields = Reflect.fields(diff).length > 1;
-            if (hasModifiedFields) {
-                final request = Env.getTierApi().updateTierConfigRequest(
-                    this.id,
-                    prepareUpdateBody(diff), this);
-                return Model.parse(TierConfigRequest, request);
+            final modifiedParams = getModifiedTcrParams();
+            if (modifiedParams != null) {
+                return this.update(modifiedParams);
             } else {
-                return this;
+                final diff = this._toDiff();
+                final hasModifiedFields = Reflect.fields(diff).length > 1;
+                if (hasModifiedFields) {
+                    final request = Env.getTierApi().updateTierConfigRequest(
+                        this.id,
+                        prepareUpdateBody(diff), this);
+                    return Model.parse(TierConfigRequest, request);
+                } else {
+                    return this;
+                }
             }
         } else {
             if (params.length() > 0) {
@@ -171,6 +176,24 @@ class TierConfigRequest extends IdModel {
                     '{"params":${params.toString()}}', this);
             }
             return this;
+        }
+    }
+
+    // If the user has modified the TCR params directly, returns a collection with them.
+    // Otherwise, returns null and modified params should be searched for in TC.
+    private function getModifiedTcrParams(): Null<Collection<Param>> {
+        final oldTcr = Model.parse(TierConfigRequest, this._footprint);
+        if (this.params.length() != oldTcr.params.length()) {
+            final oldParamsAsString = oldTcr.params.toArray().map(p -> p.toString());
+            final result = new Collection<Param>();
+            for (param in this.params.toArray()) {
+                if (oldParamsAsString.indexOf(param.toString()) == -1) {
+                    result.push(param);
+                }
+            }
+            return result;
+        } else {
+            return null;
         }
     }
 

--- a/stuff/push_tag.py
+++ b/stuff/push_tag.py
@@ -35,7 +35,8 @@ def run(args: list) -> str:
 
 
 if __name__ == '__main__':
-    if os.environ['TRAVIS_BRANCH'] == 'master':
+    branch = os.environ['TRAVIS_BRANCH']
+    if branch == 'master' or branch.startswith('release/'):
         print(remove_origin())
         print(add_origin(os.environ['doc_token']))
         tags = get_tags()
@@ -47,5 +48,5 @@ if __name__ == '__main__':
             print('Tag is not being pushed because it already exists.')
     else:
         print('Tag is not being pushed because this commit has been pushed to '
-            + os.environ['TRAVIS_BRANCH']
-            + ' branch instead of master.')
+            + branch
+            + ' branch instead of master or release/*.')


### PR DESCRIPTION
This contains a bugfix for the TierConfigRequest.update method when the TCR params array has been modified by hand. This PR backports the fix to the 20.x version of the SDK.